### PR TITLE
 Enhancement: Add state the StaleMateLoaders

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -191,6 +191,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   term_glyph:
     dependency: transitive
     description:

--- a/lib/src/exceptions/no_local_data_exception.dart
+++ b/lib/src/exceptions/no_local_data_exception.dart
@@ -1,0 +1,11 @@
+/// Exception thrown when there is no local data available.
+class NoLocalDataException implements Exception {
+  final String message;
+
+  NoLocalDataException(this.message);
+
+  @override
+  String toString() {
+    return 'NoLocalDataException: $message';
+  }
+}

--- a/lib/src/stalemate_loader/stalemate_loader_state.dart
+++ b/lib/src/stalemate_loader/stalemate_loader_state.dart
@@ -1,0 +1,218 @@
+import 'stalemate_loader.dart';
+
+/// Enum for the status of the [StaleMateLoader].
+///
+/// Enum values:
+/// - **idle:** Loading hasn't started. Loader has been reset or hasn't been initialized
+/// - **loading:** Loading is in progress.
+/// - **loaded:** Loading completed successfully, data is available or empty
+/// - **error:** Loading failed, error is available
+enum StaleMateStatus {
+  idle,
+  loading,
+  loaded,
+  error,
+}
+
+/// Enum for the reason for loading the data
+///
+/// Enum values:
+/// - **initial:** Initial load
+/// - **refresh:** Refresh
+/// - **fetchMore:** Fetch more
+enum StaleMateFetchReason {
+  initial,
+  refresh,
+  fetchMore,
+}
+
+/// This state includes two separate loading states:
+/// - **localStatus:** Represents the loading status of the local data. This can be idle, loading, loaded, or error.
+/// - **remoteStatus:** Represents the loading status of the remote data. This can also be idle, loading, loaded, or error.
+///
+/// Additionally, it includes a fetch reason, which can be initial, refresh, or fetchMore,
+/// and two separate error fields, one for local and one for remote errors.
+///
+/// Use [StaleMateLoader.state] to check the status of the loader.
+class StaleMateLoaderState {
+  /// The status of the local data
+  final StaleMateStatus localStatus;
+
+  /// The status of the remote data
+  final StaleMateStatus remoteStatus;
+
+  /// The reason for loading the data
+  final StaleMateFetchReason? fetchReason;
+
+  /// The error that was thrown while loading the data, if any
+  final Object? localError;
+
+  /// The error that was thrown while loading the data
+  /// from the remote data source
+  final Object? remoteError;
+
+  /// Creates a new [StaleMateLoaderState] object
+  ///
+  /// Arguments:
+  /// - **localStatus:** The status of the local data
+  /// - **remoteStatus:** The status of the remote data
+  /// - **fetchReason:** The reason for loading the data (null if loading hasn't started)
+  /// - **localError:** The error that was thrown while loading the local data (null if no error was thrown)
+  /// - **remoteError:** The error that was thrown while loading the remote data (null if no error was thrown)
+  StaleMateLoaderState({
+    required this.localStatus,
+    required this.remoteStatus,
+    this.fetchReason,
+    this.localError,
+    this.remoteError,
+  });
+
+  /// Loader got remote data from an initial load
+  bool get isInitalLoad => fetchReason == StaleMateFetchReason.initial;
+
+  /// Loader got remote data after a refresh
+  bool get isRefresh => fetchReason == StaleMateFetchReason.refresh;
+
+  /// Loader got remote data after fetching more
+  bool get isFetchMore => fetchReason == StaleMateFetchReason.fetchMore;
+
+  /// Local data is loading
+  bool get loadingLocal => localStatus == StaleMateStatus.loading;
+
+  /// Remote data is loading
+  bool get loadingRemote => remoteStatus == StaleMateStatus.loading;
+
+  /// Data is loading
+  ///
+  /// This is true if either the local or remote data is loading
+  bool get loading => loadingLocal || loadingRemote;
+
+  /// Local data is loaded
+  bool get loadedLocal => localStatus == StaleMateStatus.loaded;
+
+  /// Remote data is loaded
+  bool get loadedRemote => remoteStatus == StaleMateStatus.loaded;
+
+  /// Data is loaded
+  ///
+  /// This is true if either the local or remote data is loaded
+  bool get loaded => loadedLocal || loadedRemote;
+
+  /// Local data has an error
+  bool get hasLocalError => localStatus == StaleMateStatus.error;
+
+  /// Remote data has an error
+  bool get hasRemoteError => remoteStatus == StaleMateStatus.error;
+
+  /// Data has an error
+  ///
+  /// This is true if either the local or remote data has an error
+  bool get hasError => hasLocalError || hasRemoteError;
+
+  /// Local data is idle
+  bool get localIdle => localStatus == StaleMateStatus.idle;
+
+  /// Remote data is idle
+  bool get remoteIdle => remoteStatus == StaleMateStatus.idle;
+
+  /// Data is idle
+  ///
+  /// This is true if both the local and remote data is idle
+  bool get isIdle => localIdle && remoteIdle;
+
+  /// Returns the local error
+  ///
+  /// Throws an assertion error if there is no local error
+  ///
+  /// Use [hasLocalError] to check if there is an error
+  Object get requireLocalError {
+    assert(
+      hasLocalError,
+      'Cannot require local error when there is none, use hasLocalError to check if there is an error',
+    );
+    return localError!;
+  }
+
+  /// Returns the remote error
+  ///
+  /// Throws an assertion error if there is no remote error
+  ///
+  /// Use [hasRemoteError] to check if there is an error
+  Object get requireRemoteError {
+    assert(
+      hasRemoteError,
+      'Cannot require remote error when there is none, use hasRemoteError to check if there is an error',
+    );
+    return remoteError!;
+  }
+
+  /// Returns the fetch reason
+  ///
+  /// Throws an assertion error if there is no fetch reason
+  ///
+  /// Use [remoteIdle] to check if there is a reason
+  StaleMateFetchReason get requireFetchReason {
+    assert(
+      !remoteIdle,
+      'Cannot require fetch reason when there is none, use remoteIdle to check if there is a reason',
+    );
+    return fetchReason!;
+  }
+
+  factory StaleMateLoaderState.initial() {
+    return StaleMateLoaderState(
+      localStatus: StaleMateStatus.idle,
+      remoteStatus: StaleMateStatus.idle,
+    );
+  }
+
+  /// Change the local status
+  ///
+  /// Arguments:
+  /// - **status:** The new status
+  /// - **error:** The error that was thrown while loading the data (null if no error was thrown)
+  StaleMateLoaderState copyWithLocalStatus(
+    StaleMateStatus status, {
+    Object? error,
+  }) {
+    return StaleMateLoaderState(
+      localStatus: status,
+      remoteStatus: remoteStatus,
+      fetchReason: fetchReason,
+      localError: error,
+      remoteError: remoteError,
+    );
+  }
+
+  /// Change the remote status
+  /// Arguments:
+  /// - **status:** The new status
+  /// - **fetchReason:** The reason for loading the data (null if loading hasn't started)
+  /// - **error:** The error that was thrown while loading the data (null if no error was thrown)
+  StaleMateLoaderState copyWithRemoteStatus(
+    StaleMateStatus status, {
+    StaleMateFetchReason? fetchReason,
+    Object? error,
+  }) {
+    return StaleMateLoaderState(
+      localStatus: localStatus,
+      remoteStatus: status,
+      fetchReason: fetchReason ?? this.fetchReason,
+      localError: localError,
+      remoteError: error,
+    );
+  }
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.writeln('StaleMateLoaderState(');
+    buffer.writeln('  localStatus: $localStatus,');
+    buffer.writeln('  remoteStatus: $remoteStatus,');
+    buffer.writeln('  fetchReason: $fetchReason,');
+    buffer.writeln('  localError: $localError,');
+    buffer.writeln('  remoteError: $remoteError,');
+    buffer.writeln(')');
+    return buffer.toString();
+  }
+}

--- a/lib/src/stalemate_loader/stalemate_state_manager.dart
+++ b/lib/src/stalemate_loader/stalemate_state_manager.dart
@@ -1,0 +1,113 @@
+import 'package:logger/logger.dart';
+import 'package:synchronized/synchronized.dart';
+
+import 'stalemate_loader_state.dart';
+
+typedef StateListener = void Function(
+  StaleMateLoaderState state,
+  StaleMateLoaderState prevState,
+);
+
+/// Manages the state of the data loader
+///
+/// This class is used internally by the data loader
+/// to manage the state of the data loader
+///
+/// It is simply to abstract away the state management and
+/// decouple it from the data loader
+///
+/// See also:
+/// - [StaleMateLoaderState]
+class StaleMateStateManager {
+  /// A lock that is used to synchronize state changes
+  final Lock _stateLock = Lock();
+
+  /// A logger that is used to log state changes
+  final Logger _logger;
+
+  /// Creates a new state manager
+  ///
+  /// Arguments:
+  /// - **logger:** A logger that is used to log state changes
+  StaleMateStateManager({required Logger logger}) : _logger = logger;
+
+  /// Indicates what the current state of the data loader is
+  StaleMateLoaderState _state = StaleMateLoaderState.initial();
+
+  StaleMateLoaderState get state => _state;
+
+  /// Holds state listeners that will be called when the state changes
+  final List<StateListener> _stateListeners = [];
+
+  /// Changes the state of the data loader
+  ///
+  /// This method should only be used internally by the data loader
+  ///
+  /// Arguments:
+  /// - [state] : The new state of the data loader
+  Future<void> _setState(StaleMateLoaderState newState) async {
+    await _stateLock.synchronized(() {
+      final prevState = _state;
+      _state = newState;
+
+      // Call the state listeners
+      for (var listener in _stateListeners) {
+        try {
+          listener(newState, prevState);
+        } catch (e, stackTrace) {
+          _logger.e('Error while calling state listener', e, stackTrace);
+        }
+      }
+
+      _logger.d('State changed to $newState');
+    });
+  }
+
+  /// Changes the local state of the data loader
+  Future<void> setLocalState(
+    StaleMateStatus status, {
+    Object? error,
+  }) async {
+    await _setState(state.copyWithLocalStatus(
+      status,
+      error: error,
+    ));
+  }
+
+  /// Changes the remote state of the data loader
+  Future<void> setRemoteState(
+    StaleMateStatus status, {
+    StaleMateFetchReason? fetchReason,
+    Object? error,
+  }) async {
+    await _setState(state.copyWithRemoteStatus(
+      status,
+      fetchReason: fetchReason,
+      error: error,
+    ));
+  }
+
+  Future<void> reset() async {
+    await _setState(StaleMateLoaderState.initial());
+  }
+
+  /// Adds a state listener to the data loader
+  ///
+  /// The state listener will be called whenever the state of the data loader changes
+  ///
+  /// Arguments:
+  /// - [listener] : The listener that will be called when the state changes
+  void addListener(StateListener listener) {
+    _stateListeners.add(listener);
+  }
+
+  /// Removes a state listener from the data loader
+  ///
+  /// The state listener will no longer be called when the state of the data loader changes
+  ///
+  /// Arguments:
+  /// - [listener] : The listener that will be removed
+  void removeListener(StateListener listener) {
+    _stateListeners.remove(listener);
+  }
+}

--- a/lib/src/stalemate_paginated_loader/stalemate_paginated_loader.dart
+++ b/lib/src/stalemate_paginated_loader/stalemate_paginated_loader.dart
@@ -200,14 +200,14 @@ abstract class StaleMatePaginatedLoader<T> extends StaleMateLoader<List<T>> {
     if (paginationConfig.canFetchMore) {
       // If we are already fetching data, return already fetching
       if (state.loading) {
-        _logger.d('Could not fetch more. Already fetching data');
+        _logger.i('Could not fetch more. Already fetching data');
         return StaleMateFetchMoreResult<T>.alreadyFetching();
       }
 
-      _setState(state.copyWithRemoteStatus(
+      _stateManager.setRemoteState(
         StaleMateStatus.loading,
         fetchReason: StaleMateFetchReason.fetchMore,
-      ));
+      );
 
       final fetchMoreInitiatedAt = DateTime.now();
 
@@ -239,10 +239,10 @@ abstract class StaleMatePaginatedLoader<T> extends StaleMateLoader<List<T>> {
           );
         }
 
-        _setState(state.copyWithRemoteStatus(
+        _stateManager.setRemoteState(
           StaleMateStatus.loaded,
           fetchReason: StaleMateFetchReason.fetchMore,
-        ));
+        );
 
         // The data returned from the server is passed through the [onReceivedData] method
         // which handles merging the data and setting the [canFetchMore] flag
@@ -279,12 +279,10 @@ abstract class StaleMatePaginatedLoader<T> extends StaleMateLoader<List<T>> {
         // Tell the base loader to handle the error appropritaly
         _onRemoteDataError(error);
 
-        _setState(
-          state.copyWithRemoteStatus(
-            StaleMateStatus.error,
-            fetchReason: StaleMateFetchReason.fetchMore,
-            error: error,
-          ),
+        _stateManager.setRemoteState(
+          StaleMateStatus.loaded,
+          fetchReason: StaleMateFetchReason.fetchMore,
+          error: error,
         );
 
         // Return failure

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
   logger: ^1.4.0
   rxdart: ^0.27.7
+  synchronized: ^3.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/src/stalemate_loader_test.dart
+++ b/test/src/stalemate_loader_test.dart
@@ -4,7 +4,10 @@ import 'package:stalemate/stalemate.dart';
 
 class StringLoader extends StaleMateLoader<String?> {
   String? _localData;
-  bool shouldThrowError = false;
+  bool shouldThrowLocalError = false;
+  bool shouldThrowRemoteError = false;
+  bool shouldThrowWhileStoring = false;
+  bool shouldThrowWhileRemoving = false;
   int timesUpdatedFromRemote = 0;
 
   StringLoader({
@@ -18,13 +21,16 @@ class StringLoader extends StaleMateLoader<String?> {
 
   @override
   Future<String?> getLocalData() async {
+    if (shouldThrowLocalError) {
+      throw Exception('Failed to fetch local data');
+    }
     return _localData;
   }
 
   @override
   Future<String?> getRemoteData() async {
     await Future.delayed(const Duration(milliseconds: 10));
-    if (shouldThrowError) {
+    if (shouldThrowRemoteError) {
       throw Exception('Failed to fetch remote data');
     }
     return 'remote data ${++timesUpdatedFromRemote}';
@@ -32,12 +38,17 @@ class StringLoader extends StaleMateLoader<String?> {
 
   @override
   Future<void> storeLocalData(String? data) async {
+    if (shouldThrowWhileStoring) {
+      throw Exception('Failed to store local data');
+    }
     _localData = data;
   }
 
   @override
   Future<void> removeLocalData() async {
-    shouldThrowError = false;
+    if (shouldThrowWhileRemoving) {
+      throw Exception('Failed to remove local data');
+    }
     timesUpdatedFromRemote = 0;
     _localData = null;
   }
@@ -129,13 +140,13 @@ void main() {
     });
 
     test('value should be local data after error', () async {
-      stringLoader.shouldThrowError = true;
+      stringLoader.shouldThrowRemoteError = true;
       await stringLoader.initialize();
       expect(stringLoader.value, equals('initial local data'));
     });
 
     test('value should be local data after error and refresh', () async {
-      stringLoader.shouldThrowError = true;
+      stringLoader.shouldThrowRemoteError = true;
       await stringLoader.initialize();
       await stringLoader.refresh();
       expect(stringLoader.value, equals('initial local data'));
@@ -143,9 +154,320 @@ void main() {
 
     test('value should be remote data after error and refresh', () async {
       await stringLoader.initialize();
-      stringLoader.shouldThrowError = true;
+      stringLoader.shouldThrowRemoteError = true;
       await stringLoader.refresh();
       expect(stringLoader.value, equals('remote data 1'));
+    });
+  });
+
+  group('Stalemate loader state', () {
+    test('state should be idle after creation', () async {
+      final stringLoader = StringLoader();
+      expect(stringLoader.state.localStatus, equals(StaleMateStatus.idle));
+      expect(stringLoader.state.remoteStatus, equals(StaleMateStatus.idle));
+    });
+
+    test('state progress during initialization', () async {
+      final stringLoader = StringLoader();
+      stringLoader.initialize();
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loading),
+      );
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.idle),
+      );
+      await Future.delayed(const Duration(milliseconds: 5));
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loaded),
+      );
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.initial),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loaded),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.initial),
+      );
+    });
+
+    test('state progress during refresh', () async {
+      final stringLoader = StringLoader();
+      await stringLoader.initialize();
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loaded),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.initial),
+      );
+
+      stringLoader.refresh();
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loading),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.refresh),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loaded),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.refresh),
+      );
+    });
+
+    test('state progress during reset', () async {
+      final stringLoader = StringLoader();
+      await stringLoader.initialize();
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loaded),
+      );
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loaded),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.initial),
+      );
+
+      await stringLoader.reset();
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.idle),
+      );
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.idle),
+      );
+    });
+
+    test('state progress during local initial loading error', () async {
+      final stringLoader = StringLoader();
+      stringLoader.shouldThrowLocalError = true;
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.idle),
+      );
+
+      stringLoader.initialize();
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 5));
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.error),
+      );
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loaded),
+      );
+    });
+
+    test('state progress during initial remote', () async {
+      final stringLoader = StringLoader();
+      stringLoader.shouldThrowRemoteError = true;
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.idle),
+      );
+
+      stringLoader.initialize();
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 5));
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loaded),
+      );
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.error),
+      );
+    });
+
+    test(
+        'state progress during initialization with error in both local and remote',
+        () async {
+      final stringLoader = StringLoader();
+      stringLoader.shouldThrowRemoteError = true;
+      stringLoader.shouldThrowLocalError = true;
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.idle),
+      );
+
+      stringLoader.initialize();
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 5));
+
+      expect(
+        stringLoader.state.localStatus,
+        equals(StaleMateStatus.error),
+      );
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loading),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.error),
+      );
+    });
+
+    test('state progress during refresh error', () async {
+      final stringLoader = StringLoader();
+      await stringLoader.initialize();
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loaded),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.initial),
+      );
+
+      stringLoader.shouldThrowRemoteError = true;
+      stringLoader.refresh();
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.loading),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.refresh),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 15));
+
+      expect(
+        stringLoader.state.remoteStatus,
+        equals(StaleMateStatus.error),
+      );
+      expect(
+        stringLoader.state.requireFetchReason,
+        equals(StaleMateFetchReason.refresh),
+      );
+    });
+  });
+
+  group('state listeners', () {
+    test('test add state listener', () async {
+      final stringLoader = StringLoader();
+      final List<StaleMateLoaderState> states = [];
+      final List<StaleMateLoaderState> prevStates = [];
+      listener(newState, prevState) {
+        states.add(newState);
+        prevStates.add(prevState);
+      }
+
+      stringLoader.addStateListener(listener);
+      await stringLoader.initialize();
+
+      // During initialize, the state listener is called 4 times
+      // 1. Initial state to loading local
+      // 2. Local loading to local loaded
+      // 3. Local loaded to loading remote as well
+      // 4. Remote loaded
+
+      expect(states.length, equals(4));
+      expect(states[0].localStatus, equals(StaleMateStatus.loading));
+      expect(states[1].localStatus, equals(StaleMateStatus.loaded));
+      expect(states[2].remoteStatus, equals(StaleMateStatus.loading));
+      expect(states[3].remoteStatus, equals(StaleMateStatus.loaded));
+
+      expect(prevStates.length, equals(4));
+      expect(prevStates[0].localStatus, equals(StaleMateStatus.idle));
+      expect(prevStates[1].localStatus, equals(StaleMateStatus.loading));
+      expect(prevStates[2].localStatus, equals(StaleMateStatus.loaded));
+      expect(prevStates[3].remoteStatus, equals(StaleMateStatus.loading));
+    });
+
+    test('test remove state listener', () async {
+      final stringLoader = StringLoader();
+      final List<StaleMateLoaderState> states = [];
+      listener(newState, prevState) => states.add(newState);
+
+      stringLoader.addStateListener(listener);
+      await stringLoader.initialize();
+
+      expect(states.length, equals(4));
+      expect(states[0].localStatus, equals(StaleMateStatus.loading));
+      expect(states[1].localStatus, equals(StaleMateStatus.loaded));
+      expect(states[2].remoteStatus, equals(StaleMateStatus.loading));
+      expect(states[3].remoteStatus, equals(StaleMateStatus.loaded));
+
+      stringLoader.removeStateListener(listener);
+      await stringLoader.refresh();
+
+      expect(states.length, equals(4));
+      expect(states[0].localStatus, equals(StaleMateStatus.loading));
+      expect(states[1].localStatus, equals(StaleMateStatus.loaded));
+      expect(states[2].remoteStatus, equals(StaleMateStatus.loading));
+      expect(states[3].remoteStatus, equals(StaleMateStatus.loaded));
     });
   });
 }


### PR DESCRIPTION
This PR introduces a "state" property to the loader, which indicates what state the loader is in. It has separate statuses for the local and remote data, and contains the latest error for each of them as well as the "fetchReason" for the remote data.

This PR closes issue #10 

A simplified version of it looks like this:
```dart
class StaleMateLoaderState {
  final StaleMateStatus localStatus;
  final StaleMateStatus remoteStatus;
  final StaleMateFetchReason? fetchReason;
  final Object? localError;
  final Object? remoteError;
}
```

The **StaleMateStatus** can be one of the following
- **idle**
- **loading**
- **loaded** 
-  **error**

The **StaleMateFetchReason** can be one of the following:
- **initial**
- **refresh**
-  **fetchMore**

The ability to listen to state changes was also added, by calling **addStateListener** and **removeStateListener** on the loader