### PR TITLE
Refactor StaleMate Loaders to Use StaleMateHandlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## Version 0.0.1
 
-Initial Version of the library.
+Initial Version
 
 Features:
 
 - **StaleMateLoader:** Core loader for managing stale data and facilitating automatic refresh.
 - **StaleMatePaginatedLoader:** A loader that supports paginating data from remote
+- **StaleMateHandler:** The core interface for integrating with your data sources. By extending StaleMateHandler, you can easily manage fetching and storing data in both local and remote sources.
 - **Automatic Refreshing:** Two built-in strategies for automatic data refreshing - stale period and time-of-day.
 - **Custom Refresh Strategy:** Offers flexibility to define custom refresh strategies tailored to your application's specific needs.
 - **StaleMateBuilder:** Stream-based builder for seamless UI updates based on the current data state.
 - **StaleMateRegistry** Offers bulk operations on loaders to simplify common operations like clearing all loaders on logout
-- **Example Application:** A simple example application to help you get started with the library.
-- **Documentation:** Minimal documentation included to guide you through the library's basic features and usage.
+- **Example Application:** A simple example application to help you get started.
+- **Documentation:** Documentation to guide you through the library's basic features and usage.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ class TodosHandler extends StaleMateHandler<List<ToDo>> {
 
 For data that is not stored server side, extend the **LocalOnlyStaleMateHandler** instead of the **StaleMateHandler**. The main difference is that you won't override the getRemoteData method.
 
-> You can update the data by calling **addData(updatedTodos)** on the loader, see [Manually refreshing the data](#manually-refreshing-the-data)
+> You can update the data by calling **addData(updatedTodos)** on the loader, see [Manually adding data](#manually-adding-data)
 
 Here's an example of a local-only ToDo handler implementation:
 
@@ -320,7 +320,7 @@ Alternatively, you can achieve the same result by using a **StreamBuilder**:
           );
         }
 
-        if (snapshot.hasData && snapshot.data == _todosLoader.emptyValue) {
+        if (snapshot.hasData && !todosLoader.isEmpty) {
           return const Center(
             child: Text('No todos'),
           );
@@ -371,7 +371,7 @@ if (result.isSuccess) {
 The StaleMateRefreshResult object also contains a convenient **on** method:
 
 ```dart
-(await _todosLoader.refresh()).on(
+(await todosLoader.refresh()).on(
     success: (data) {
         // do something on succesful refresh
     },
@@ -386,7 +386,7 @@ The StaleMateRefreshResult object also contains a convenient **on** method:
 You can reset the loader to its initial empty state and remove any local data by calling the **reset** method:
 
 ```dart
-_todosLoader.reset();
+todosLoader.reset();
 ```
 
 ### Manually adding data
@@ -717,7 +717,7 @@ logoutUser() async {
 }
 
 refreshAllTodoLoaders() async {
-    final List<StaleMateRefreshResult> refreshResults = await StaleMate.refreshLoaders<List<ToDo>, TodosHandler>();
+    final List<StaleMateRefreshResult> refreshResults = await StaleMate.refreshLoadersWithHandler<List<ToDo>, TodosHandler>();
 }
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:example/pages/initialization_refresh/initalization_refresh.dart';
+import 'package:example/pages/simple_usage/simple_usage.dart';
 import 'package:flutter/material.dart';
 
 import 'pages/home_page/home_page.dart';
@@ -14,8 +14,8 @@ void main() {
       ),
       home: const HomePage(), // becomes the route named '/'
       routes: <String, WidgetBuilder>{
-        '/initialization_refresh': (BuildContext context) =>
-            const InitializationRefresh(),
+        '/simple_usage': (BuildContext context) =>
+            const SimpleUsage(),
         'paginated_loader': (context) => const PaginatedLoaderPage(),
       },
     ),

--- a/example/lib/pages/home_page/home_page.dart
+++ b/example/lib/pages/home_page/home_page.dart
@@ -12,8 +12,8 @@ class HomePage extends StatelessWidget {
       body: ListView(
         children: const [
           HomePageListItem(
-            title: 'Initialization and Refresh',
-            path: '/initialization_refresh',
+            title: 'Simple usage',
+            path: '/simple_usage',
           ),
           HomePageListItem(
             title: 'Paginated Loader',

--- a/example/lib/pages/paginated_loader_page/data/handlers/paginated_example_handler.dart
+++ b/example/lib/pages/paginated_loader_page/data/handlers/paginated_example_handler.dart
@@ -7,6 +7,8 @@ import '../datasources/paginated_example_remote_datasource.dart';
 /// The data is loaded from a fake remote source ([PaginatedExampleRemoteDatasource])
 /// and the pagination is handled by the [StaleMatePaginatedLoader]
 ///
+/// Uses the [PaginatedHandlerMixin] to get the pagination functionality
+///
 /// See also:
 /// - [StaleMatePaginatedLoader]
 /// - [PaginatedExampleRemoteDatasource]
@@ -14,7 +16,13 @@ import '../datasources/paginated_example_remote_datasource.dart';
 /// - [StaleMatePagePagination]
 /// - [StaleMateOffsetLimitPagination]
 /// - [StaleMateCursorPagination]
-class PaginatedExampleLoader extends StaleMatePaginatedLoader<String> {
+class PaginatedExampleHandler extends RemoteOnlyStaleMateHandler<List<String>>
+    // Use the PaginatedHandlerMixin to get the pagination functionality
+    with
+        PaginatedHandlerMixin<String> {
+  /// The remote datasource used to fetch the paginated data
+  ///
+  /// In this example, the data is fetched from a fake remote source
   final PaginatedExampleRemoteDatasource _remoteDatasource =
       PaginatedExampleRemoteDatasource();
 
@@ -23,18 +31,10 @@ class PaginatedExampleLoader extends StaleMatePaginatedLoader<String> {
   /// If this flag is set to true, the [getRemotePaginatedData] method will throw
   bool shouldThrowError = false;
 
-  /// Creates a [PaginatedExampleLoader]
-  ///
-  /// Arguments:
-  /// - **paginationConfig:** The pagination config that will be used to paginate the data
-  ///     - [StaleMatePagePagination] : For page based pagination
-  ///     - [StaleMateOffsetLimitPagination] : For offset limit based pagination
-  ///     - [StaleMateCursorPagination] : For cursor based pagination
-  /// - **logLevel:** The log level that will be used to log messages
-  PaginatedExampleLoader({
-    required super.paginationConfig,
-    super.logLevel,
-  });
+  /// Provides an empty value for when the loader is reset
+  /// and to determine if the loader is empty
+  @override
+  List<String> get emptyValue => [];
 
   /// This method is called when the [StaleMatePaginatedLoader] needs to fetch remote data
   ///

--- a/example/lib/pages/paginated_loader_page/widgets/paginated_loader_example_widget.dart
+++ b/example/lib/pages/paginated_loader_page/widgets/paginated_loader_example_widget.dart
@@ -1,4 +1,4 @@
-import 'package:example/pages/paginated_loader_page/data/loaders/paginated_example_loader.dart';
+import 'package:example/pages/paginated_loader_page/data/handlers/paginated_example_handler.dart';
 import 'package:example/services/snack_bar_service.dart';
 import 'package:example/widgets/app_page_button.dart';
 import 'package:example/widgets/app_page_buttons.dart';
@@ -47,8 +47,10 @@ class _PaginatedLoaderExampleState extends State<PaginatedLoaderExampleWidget> {
   /// Used to scroll to the top of the list when refreshing
   final ScrollController scrollController = ScrollController();
 
+  final PaginatedExampleHandler handler = PaginatedExampleHandler();
+
   /// This is the loader that will be used throughout the page
-  late PaginatedExampleLoader loader;
+  late StaleMatePaginatedLoader<String, PaginatedExampleHandler> loader;
 
   /// This is just a utility service to show snack bars
   late SnackBarService snackBarService;
@@ -70,7 +72,8 @@ class _PaginatedLoaderExampleState extends State<PaginatedLoaderExampleWidget> {
     });
 
     // Create the loader with the pagination configuration
-    loader = PaginatedExampleLoader(
+    loader = StaleMatePaginatedLoader(
+      handler: handler,
       paginationConfig: widget.paginationConfig,
       // The loader will use the [StaleMateLogLevel.debug] log level
       // This is just to show the logs in the console of the example app
@@ -147,7 +150,7 @@ class _PaginatedLoaderExampleState extends State<PaginatedLoaderExampleWidget> {
     // This would not be done in a real app, it is just to show the error handling
     // of the loader, the loader would through when a remote request fails
     if (withError) {
-      loader.shouldThrowError = true;
+      handler.shouldThrowError = true;
     }
 
     // The fetchMore method can be awaited to know when the loader has finished
@@ -157,7 +160,7 @@ class _PaginatedLoaderExampleState extends State<PaginatedLoaderExampleWidget> {
     final fetchMoreResult = await loader.fetchMore();
 
     // reset the error flag
-    loader.shouldThrowError = false;
+    handler.shouldThrowError = false;
 
     // The [StaleMateFetchMoreResult.on] is a utility method that can be used to handle
     // the result of the fetch more operation, but it is a simplified version of the
@@ -214,7 +217,7 @@ class _PaginatedLoaderExampleState extends State<PaginatedLoaderExampleWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return StaleMateBuilder<List<String>>(
+    return StaleMateBuilder<List<String>, PaginatedExampleHandler>(
       loader: loader,
       builder: (context, data) {
         return data.when(

--- a/example/lib/pages/simple_usage/handlers/simple_stale_mate_handler.dart
+++ b/example/lib/pages/simple_usage/handlers/simple_stale_mate_handler.dart
@@ -1,6 +1,6 @@
 import 'package:stalemate/stalemate.dart';
 
-/// This is a simple [StaleMateLoader] that uses a [String] as the data type.
+/// This is a simple [StaleMateHandler] that uses a [String] as the data type.
 ///
 /// It has fake data flow that simulates a local and remote data source.
 /// - The local data is initialized to 'initial local data'.
@@ -8,27 +8,21 @@ import 'package:stalemate/stalemate.dart';
 ///   is incremented.
 /// - If [shouldThrowError] is set to true, [getRemoteData] will throw an error
 ///   to simulate an error when fetching remote data.
-class SimpleStaleMateLoader extends StaleMateLoader<String> {
+class SimpleStaleMateHandler extends StaleMateHandler<String> {
   String _localData = 'initial local data';
   bool shouldThrowError = false;
   int timesUpdatedFromRemote = 0;
 
-  /// Creates a [SimpleStaleMateLoader] with the given parameters.
-  ///
-  /// Arguments:
-  /// - [logLevel] - The [StaleMateLogLevel] to use, defaults to [StaleMateLogLevel.none].
-  /// - [updateOnInit] - Whether to update the data on initialization, defaults to true.
-  /// - [showLocalDataOnError] - Whether to show the local data when an error, defaults to true.
-  SimpleStaleMateLoader({
-    super.logLevel,
-    super.updateOnInit,
-    super.showLocalDataOnError,
-  }) : super(
-          // The empty value is used to determine if the data is empty.
-          // In this case, the empty value is an empty string, but if the type
-          // was a list, it would be an empty list, etc.
-          emptyValue: '',
-        );
+  /// Creates a [SimpleStaleMateHandler] instance.
+  SimpleStaleMateHandler();
+
+  /// This is the method that is called to get the empty value.
+  /// 
+  /// It needs to be overridden to return the empty value.
+  /// 
+  /// In this case, it just returns an empty string.
+  @override
+  String get emptyValue => '';
 
   /// This is the method that is called to get the local data.
   ///

--- a/example/lib/pages/simple_usage/simple_usage.dart
+++ b/example/lib/pages/simple_usage/simple_usage.dart
@@ -1,37 +1,39 @@
-import 'package:example/pages/initialization_refresh/loaders/simple_stale_mate_loader.dart';
-import 'package:example/pages/initialization_refresh/widgets/initialization_refresh_emty_state.dart';
-import 'package:example/pages/initialization_refresh/widgets/initialization_refresh_error_state.dart';
+import 'package:example/pages/simple_usage/handlers/simple_stale_mate_handler.dart';
+import 'package:example/pages/simple_usage/widgets/simple_usage_empty_state.dart';
+import 'package:example/pages/simple_usage/widgets/simple_usage_error_state.dart';
 import 'package:example/widgets/base_app_page.dart';
 import 'package:flutter/material.dart';
 import 'package:stalemate/stalemate.dart';
 
 import '../../services/snack_bar_service.dart';
-import 'widgets/initialization_refresh_data_state.dart';
-import 'widgets/initialization_refresh_loading_state.dart';
+import 'widgets/simple_usage_data_state.dart';
+import 'widgets/simple_usage_loading_state.dart';
 
-/// This page demonstrates how to use the [SimpleStaleMateLoader] to
-/// initialize and refresh data.
+/// This page demonstrates how to use the [StaleMateLoader] to initialize and refresh data
 ///
-/// The loader is initialized in the [initState] method
-class InitializationRefresh extends StatefulWidget {
-  const InitializationRefresh({super.key});
+/// This example uses a [SimpleStaleMateHandler] to handle the data
+///
+/// See also:
+/// - [SimpleStaleMateHandler]
+/// - [StaleMateLoader]
+/// - [StaleMateHandler]
+class SimpleUsage extends StatefulWidget {
+  const SimpleUsage({super.key});
 
   @override
-  State<InitializationRefresh> createState() => _InitializationRefreshState();
+  State<SimpleUsage> createState() => _SimpleUsageState();
 }
 
-class _InitializationRefreshState extends State<InitializationRefresh> {
-  // The loader that provides the data
-  final loader = SimpleStaleMateLoader(
-    // The log level is set to debug to show the logs in the console
-    // Debug is very verbose and can be turned off if preferred
-    // The default value is [StaleMateLogLevel.none]
-    // Nothing will log in release mode
-    logLevel: StaleMateLogLevel.debug,
-  );
+class _SimpleUsageState extends State<SimpleUsage> {
+  /// The handler that handles the data, in this case a [SimpleStaleMateHandler]
+  final SimpleStaleMateHandler handler = SimpleStaleMateHandler();
+
+  // The loader that provides the data through the handler
+  late StaleMateLoader<String, SimpleStaleMateHandler> loader;
 
   /// State variables to track the state of the loader,
   /// so that the UI can be updated accordingly
+  /// Note, this depends on the UI implementation, it is just a simple example
 
   /// Loader is currently initializing
   bool initializing = false;
@@ -47,6 +49,20 @@ class _InitializationRefreshState extends State<InitializationRefresh> {
 
   /// Combined state variable to track if the loader is currently loading
   bool get isLoading => initializing || refreshing || errorRefreshing;
+
+  @override
+  void initState() {
+    loader = StaleMateLoader(
+      handler: handler,
+      // The log level is set to debug to show the logs in the console
+      // Debug is very verbose and can be turned off if preferred
+      // The default value is [StaleMateLogLevel.none]
+      // Nothing will log in release mode
+      logLevel: StaleMateLogLevel.debug,
+    );
+
+    super.initState();
+  }
 
   /// When the widget is disposed of, the loader should be closed
   @override
@@ -83,15 +99,12 @@ class _InitializationRefreshState extends State<InitializationRefresh> {
   ///
   /// The [StaleMateLoader.refresh] method can be called to refresh the data
   ///
-  /// The [StaleMateLoader.refresh] method can be awaited to know when the loader has finished
-  /// refreshing the data
-  ///
   /// The [StaleMateLoader.refresh] method returns a [StaleMateRefreshResult] object that can be used
   /// to handle the result of the refresh operation
   Future<bool> performRefresh() async {
     final result = await loader.refresh();
 
-    // You can use the [StaleMateRefreshResult.on] method to handle the result of
+    // The [StaleMateRefreshResult.on] method can be used to handle the result of
     // the refresh operation, especially useful if you want to show a message to the user
     result.on(
       success: (data) {
@@ -144,11 +157,11 @@ class _InitializationRefreshState extends State<InitializationRefresh> {
     setState(() {
       errorRefreshing = true;
     });
-    // This is not a method that is available on the loader, it is just a flag
+    // This is not a method that is available on the handler, it is just a flag
     // that is used to simulate an error during the refresh operation
-    loader.shouldThrowError = true;
+    handler.shouldThrowError = true;
     await performRefresh();
-    loader.shouldThrowError = false;
+    handler.shouldThrowError = false;
     setState(() {
       errorRefreshing = false;
     });
@@ -174,7 +187,7 @@ class _InitializationRefreshState extends State<InitializationRefresh> {
       // use the [StaleMateLoader.stream] directly in the UI
       // The StaleMateBuilder widget is just a utility widget that makes it
       // easier to build the UI based on the state of the loader
-      body: StaleMateBuilder<String>(
+      body: StaleMateBuilder<String, SimpleStaleMateHandler>(
         loader: loader,
         builder: (context, data) {
           // The StaleMateBuilder widget provides the data as a [StaleMateData]
@@ -186,11 +199,11 @@ class _InitializationRefreshState extends State<InitializationRefresh> {
           // The [StaleMateData.when] method is also a convinient method to build the UI based on
           // the state of the data
           return data.when(
-            loading: () => InitializationRefreshLoadingState(
+            loading: () => SimpleUsageLoadingState(
               initializeLoader: initializeLoader,
               initializing: initializing,
             ),
-            data: (data) => InitializationRefreshDataState(
+            data: (data) => SimpleUsageDataState(
               refreshLoader: refreshLoader,
               refreshLoaderWithError: refreshLoaderWithError,
               resetLoader: resetLoader,
@@ -200,14 +213,14 @@ class _InitializationRefreshState extends State<InitializationRefresh> {
               isLoading: isLoading,
               data: data,
             ),
-            empty: () => InitializationRefreshEmptyState(
+            empty: () => SimpleUsageEmptyState(
               refreshLoader: refreshLoader,
               refreshLoaderWithError: refreshLoaderWithError,
               refreshing: refreshing,
               errorRefreshing: errorRefreshing,
               isLoading: isLoading,
             ),
-            error: (error) => InitializationRefreshErrorState(
+            error: (error) => SimpleUsageErrorState(
               refreshLoader: refreshLoader,
               resetLoader: resetLoader,
               refreshing: refreshing,

--- a/example/lib/pages/simple_usage/widgets/simple_usage_data_state.dart
+++ b/example/lib/pages/simple_usage/widgets/simple_usage_data_state.dart
@@ -4,7 +4,7 @@ import 'package:example/widgets/app_page_title.dart';
 import 'package:example/widgets/bullet_points.dart';
 import 'package:flutter/material.dart';
 
-class InitializationRefreshDataState extends StatelessWidget {
+class SimpleUsageDataState extends StatelessWidget {
   final VoidCallback refreshLoader;
   final VoidCallback refreshLoaderWithError;
   final VoidCallback resetLoader;
@@ -14,7 +14,7 @@ class InitializationRefreshDataState extends StatelessWidget {
   final bool isLoading;
   final String data;
 
-  const InitializationRefreshDataState({
+  const SimpleUsageDataState({
     Key? key,
     required this.refreshLoader,
     required this.refreshLoaderWithError,

--- a/example/lib/pages/simple_usage/widgets/simple_usage_empty_state.dart
+++ b/example/lib/pages/simple_usage/widgets/simple_usage_empty_state.dart
@@ -4,14 +4,14 @@ import 'package:example/widgets/app_page_title.dart';
 import 'package:example/widgets/bullet_points.dart';
 import 'package:flutter/material.dart';
 
-class InitializationRefreshEmptyState extends StatelessWidget {
+class SimpleUsageEmptyState extends StatelessWidget {
   final VoidCallback refreshLoader;
   final VoidCallback refreshLoaderWithError;
   final bool refreshing;
   final bool errorRefreshing;
   final bool isLoading;
 
-  const InitializationRefreshEmptyState({
+  const SimpleUsageEmptyState({
     Key? key,
     required this.refreshLoader,
     required this.refreshLoaderWithError,

--- a/example/lib/pages/simple_usage/widgets/simple_usage_error_state.dart
+++ b/example/lib/pages/simple_usage/widgets/simple_usage_error_state.dart
@@ -4,7 +4,7 @@ import 'package:example/widgets/app_page_title.dart';
 import 'package:example/widgets/bullet_points.dart';
 import 'package:flutter/material.dart';
 
-class InitializationRefreshErrorState extends StatelessWidget {
+class SimpleUsageErrorState extends StatelessWidget {
   final VoidCallback refreshLoader;
   final VoidCallback resetLoader;
   final bool refreshing;
@@ -12,7 +12,7 @@ class InitializationRefreshErrorState extends StatelessWidget {
   final bool isLoading;
   final Object error;
 
-  const InitializationRefreshErrorState({
+  const SimpleUsageErrorState({
     Key? key,
     required this.refreshLoader,
     required this.resetLoader,

--- a/example/lib/pages/simple_usage/widgets/simple_usage_loading_state.dart
+++ b/example/lib/pages/simple_usage/widgets/simple_usage_loading_state.dart
@@ -3,11 +3,11 @@ import 'package:example/widgets/app_page_title.dart';
 import 'package:example/widgets/bullet_points.dart';
 import 'package:flutter/widgets.dart';
 
-class InitializationRefreshLoadingState extends StatelessWidget {
+class SimpleUsageLoadingState extends StatelessWidget {
   final VoidCallback initializeLoader;
   final bool initializing;
 
-  const InitializationRefreshLoadingState({
+  const SimpleUsageLoadingState({
     Key? key,
     required this.initializeLoader,
     required this.initializing,

--- a/lib/src/exceptions/not_supported_exception.dart
+++ b/lib/src/exceptions/not_supported_exception.dart
@@ -1,0 +1,11 @@
+/// Exception thrown when a feature is not supported
+class NotSupportedException implements Exception {
+  final String message;
+
+  NotSupportedException(this.message);
+
+  @override
+  String toString() {
+    return 'NotSupportedException: $message';
+  }
+}

--- a/lib/src/stalemate_builder/stalemate_builder.dart
+++ b/lib/src/stalemate_builder/stalemate_builder.dart
@@ -36,12 +36,13 @@ import 'package:stalemate/stalemate.dart';
 ///     error: (error) => Text('Error: $error'),
 /// );
 /// ```
-class StaleMateBuilder<T> extends StatelessWidget {
+class StaleMateBuilder<T, R extends StaleMateHandler<T>>
+    extends StatelessWidget {
   /// The loader that provides the data
   ///
   /// The [StaleMateBuilder] will rebuild the UI based on the state of the data
   /// provided by the [StaleMateLoader.stream]
-  final StaleMateLoader<T> loader;
+  final StaleMateLoader<T, R> loader;
 
   /// The builder that will be called when the data changes
   ///
@@ -69,7 +70,7 @@ class StaleMateBuilder<T> extends StatelessWidget {
       return StaleMateData<T>(
           errorData: snapshot.error, state: StaleMateDataState.error);
     }
-    if (snapshot.hasData && snapshot.data != loader.emptyValue) {
+    if (snapshot.hasData && !loader.isEmpty) {
       return StaleMateData<T>(
           data: snapshot.requireData, state: StaleMateDataState.loaded);
     }

--- a/lib/src/stalemate_builder/stalemate_data.dart
+++ b/lib/src/stalemate_builder/stalemate_data.dart
@@ -179,7 +179,7 @@ class StaleMateData<T> {
   @override
   String toString() {
     final buffer = StringBuffer();
-    buffer.write('StaleMateData{');
+    buffer.writeln('StaleMateData{');
     buffer.writeln('    data: $data, ');
     buffer.writeln('    errorData: $errorData, ');
     buffer.writeln('    state: $state, ');

--- a/lib/src/stalemate_loader/stalemate_handler.dart
+++ b/lib/src/stalemate_loader/stalemate_handler.dart
@@ -1,0 +1,295 @@
+import '../exceptions/not_supported_exception.dart';
+import '../stalemate_loader/stalemate_loader.dart';
+
+/// A handler to retrieve and store data for [StaleMateLoader]s
+///
+/// This class is abstract and should be extended to implement the data retrieval
+/// and storage for a [StaleMateLoader]
+///
+/// This class is intended to be used for data that is stored locally and remotely
+/// Other usecases:
+/// - [LocalOnlyStaleMateHandler] for data that is only stored locally
+/// - [RemoteOnlyStaleMateHandler] for data that is only stored remotely
+///
+/// Implementation instructions:
+/// - Override the [emptyValue] getter to provide the empty value for the data type
+/// - Override the [getLocalData] method to provide the local data retrieval
+/// - Override the [getRemoteData] method to provide the remote data retrieval
+/// - Override the [storeLocalData] method to provide the local data storage
+/// - Override the [removeLocalData] method to provide the local data removal
+///
+/// To add pagination support, use the [PaginatedHandlerMixin] mixin
+///
+/// Example:
+/// ```dart
+/// class MyStaleMateHandler extends StaleMateHandler<List<MyData>> {
+///   @override
+///   List<MyData> get emptyValue => [];
+///
+///   @override
+///   Future<List<MyData>> getLocalData() async {
+///     // Load the data from the local data source
+///     return _localDataSource.getData();
+///   }
+///
+///   @override
+///   Future<List<MyData>> getRemoteData() async {
+///     // Load the data from the remote data source
+///     return _remoteDataSource.getData();
+///   }
+///
+///   @override
+///   Future<void> storeLocalData(List<MyData> data) async {
+///     // Store the data in the local data source
+///     await _localDataSource.storeData(data);
+///   }
+///
+///   @override
+///   Future<void> removeLocalData() async {
+///     // Remove the data from the local data source
+///     await _localDataSource.removeData();
+///   }
+///
+/// }
+/// ```
+abstract class StaleMateHandler<T> {
+  /// The empty value for this handler
+  ///
+  /// This is used to determine when the data is empty
+  /// Usually an empty represenation of the data type
+  ///
+  /// Due to the nature of Dart, this cannot be provided properly by the library
+  /// It would be possible to provide a default value for some types, but not types
+  /// with custom classes or enums.
+  ///
+  /// In most cases I suspect this library will be used with custom classes or enums
+  /// and providing a default value for a subset of types could be confusing.
+  ///
+  /// Examples:
+  /// - `''` for [String]
+  /// - `null` for any nullable type
+  /// - `-1` for [int]
+  /// - `-1.0` for [double]
+  /// - `[]` for [List]
+  /// - `{}` for [Map]
+  /// - `State.initial`for a custom State enum
+  T get emptyValue;
+
+  /// Retrieves the data from the local source
+  ///
+  /// **Override this method to implement local data retrieval**
+  ///
+  /// This method will be called when local data is requested.
+  ///
+  /// How to implement:
+  /// - Retrieve the data from wherever it is stored locally
+  /// - Return the local data
+  /// - If the local data is empty, return the [emptyValue]
+  /// - If there is an error retrieving the local data, throw the error
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// Future<List<MyData>> getLocalData() async {
+  ///  // Load the data from the local data source
+  ///  return _localDataSource.getData();
+  /// }
+  /// ```
+  Future<T> getLocalData();
+
+  /// Retrieves the data from the remote source
+  ///
+  /// **Override this method to implement remote data retrieval**
+  ///
+  /// This method will be called when remote data is requested.
+  ///
+  /// How to implement:
+  /// - Retrieve the data from the remote source
+  /// - Return the remote data
+  /// - If the remote data is empty, return the [emptyValue]
+  /// - If there is an error retrieving the remote data, throw the error
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// Future<List<MyData>> getRemoteData() async {
+  ///   // Load the data from the remote data source
+  ///   return _remoteDataSource.getData();
+  /// }
+  /// ```
+  Future<T> getRemoteData();
+
+  /// Stores the data in the local source
+  ///
+  /// **Override this method to implement local data storage**
+  ///
+  /// This method will be called when the data should be stored locally.
+  ///
+  /// How to implement:
+  /// - Store the data in the local data source
+  /// - If there is an error storing the data, throw the error
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// Future<void> storeLocalData(List<MyData> data) async {
+  ///   // Store the data in the local data source
+  ///   await _localDataSource.storeData(data);
+  /// }
+  /// ```
+  Future<void> storeLocalData(T data);
+
+  /// Removes the data from the local source
+  ///
+  /// **Override this method to implement local data removal**
+  ///
+  /// This method will be called when the data should be removed from the local source.
+  ///
+  /// How to implement:
+  /// - Remove the data from the local data source
+  /// - If there is an error removing the data, throw the error
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// Future<void> removeLocalData() async {
+  ///   // Remove the data from the local data source
+  ///   await _localDataSource.removeData();
+  /// }
+  /// ```
+  Future<void> removeLocalData();
+}
+
+/// A handler to retrieve and store local for [StaleMateLoader]s
+///
+/// This class is abstract and should be extended to implement the local data retrieval
+/// and storage for a [StaleMateLoader]
+///
+/// This class is intended to be used for data that is only stored locally
+/// - [StaleMateHandler] for data that is stored locally and remotely
+/// - [RemoteOnlyStaleMateHandler] for data that is only stored remotely
+///
+/// Implementation instructions:
+/// - Override the [emptyValue] getter to provide the empty value for the data type
+/// - Override the [getLocalData] method to provide the local data retrieval
+/// - Override the [storeLocalData] method to provide the local data storage
+/// - Override the [removeLocalData] method to provide the local data removal
+///
+/// Example:
+/// ```dart
+/// class MyStaleMateHandler extends StaleMateHandler<List<MyData>> {
+///   @override
+///   List<MyData> get emptyValue => [];
+///
+///   @override
+///   Future<List<MyData>> getLocalData() async {
+///     // Load the data from the local data source
+///     return _localDataSource.getData();
+///   }
+///
+///
+///   @override
+///   Future<void> storeLocalData(List<MyData> data) async {
+///     // Store the data in the local data source
+///     await _localDataSource.storeData(data);
+///   }
+///
+///   @override
+///   Future<void> removeLocalData() async {
+///     // Remove the data from the local data source
+///     await _localDataSource.removeData();
+///   }
+///
+/// }
+/// ```
+abstract class LocalOnlyStaleMateHandler<T> extends StaleMateHandler<T> {
+  @override
+  Future<T> getRemoteData() {
+    throw NotSupportedException(
+      'Remote data is not supported in LocalOnlyStaleMateHandler',
+    );
+  }
+
+  @override
+  Future<T> getLocalData();
+
+  @override
+  Future<void> storeLocalData(T data);
+
+  @override
+  Future<void> removeLocalData();
+}
+
+/// A handler to retrieve and store remote data for [StaleMateLoader]s
+///
+/// This class is abstract and should be extended to implement the data retrieval
+/// and storage for a [StaleMateLoader]
+///
+/// This class is intended to be used for data that is only stored remotely
+/// Other usecases:
+/// - [StaleMateHandler] for data that is stored locally and remotely
+/// - [LocalOnlyStaleMateHandler] for data that is only stored locally
+///
+/// Implementation instructions:
+/// - Override the [emptyValue] getter to provide the empty value for the data type
+/// - Override the [getRemoteData] method to provide the remote data retrieval
+///
+/// To add pagination support, use the [PaginatedHandlerMixin] mixin
+///
+/// Example:
+/// ```dart
+/// class MyStaleMateHandler extends StaleMateHandler<List<MyData>> {
+///   @override
+///   List<MyData> get emptyValue => [];
+///
+///   @override
+///   Future<List<MyData>> getLocalData() async {
+///     // Load the data from the local data source
+///     return _localDataSource.getData();
+///   }
+///
+///   @override
+///   Future<List<MyData>> getRemoteData() async {
+///     // Load the data from the remote data source
+///     return _remoteDataSource.getData();
+///   }
+///
+///   @override
+///   Future<void> storeLocalData(List<MyData> data) async {
+///     // Store the data in the local data source
+///     await _localDataSource.storeData(data);
+///   }
+///
+///   @override
+///   Future<void> removeLocalData() async {
+///     // Remove the data from the local data source
+///     await _localDataSource.removeData();
+///   }
+///
+/// }
+/// ```
+abstract class RemoteOnlyStaleMateHandler<T> extends StaleMateHandler<T> {
+  @override
+  Future<T> getRemoteData();
+
+  @override
+  Future<T> getLocalData() {
+    throw NotSupportedException(
+      'Local data is not supported in RemoteOnlyStaleMateHandler',
+    );
+  }
+
+  @override
+  Future<void> storeLocalData(T data) {
+    throw NotSupportedException(
+      'Local data is not supported in RemoteOnlyStaleMateHandler',
+    );
+  }
+
+  @override
+  Future<void> removeLocalData() {
+    throw NotSupportedException(
+      'Local data is not supported in RemoteOnlyStaleMateHandler',
+    );
+  }
+}

--- a/lib/src/stalemate_loader/stalemate_loader.dart
+++ b/lib/src/stalemate_loader/stalemate_loader.dart
@@ -409,7 +409,7 @@ class StaleMateLoader<T, HandlerType extends StaleMateHandler<T>> {
 
   /// Resets the loader
   ///
-  /// - If [removeLocalData] is implemented, removes local data
+  /// - Removes local data if supported by handler
   /// - Adds empty value to stream
   Future<void> reset() async {
     _logger.i('Resetting data...');

--- a/lib/src/stalemate_loader/stalemate_loader.dart
+++ b/lib/src/stalemate_loader/stalemate_loader.dart
@@ -1,108 +1,42 @@
-import 'package:async/async.dart';
+import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
 import 'package:rxdart/subjects.dart';
-
 import '../exceptions/no_local_data_exception.dart';
+import '../exceptions/not_supported_exception.dart';
 import '../logging/stalemate_log_level.dart';
 import '../logging/tagged_logging_printer.dart';
+import '../stalemate_paginated_loader/stale_mate_paginated_handler_mixin.dart';
 import '../stalemate_refresher/stalemate_refresh_result.dart';
 import '../stalemate_paginated_loader/stale_mate_fetch_more_result.dart';
 import '../stalemate_refresher/stalemate_refresh_config.dart';
 import '../stalemate_refresher/stalemate_refresher.dart';
 import '../stalemate_registry/stalemate_registry.dart';
 import '../stalemate_paginated_loader/stalemate_pagination_config.dart';
+import 'stalemate_handler.dart';
 import 'stalemate_loader_state.dart';
 import 'stalemate_state_manager.dart';
 
 export '../logging/stalemate_log_level.dart';
 export 'stalemate_loader_state.dart';
+export 'stalemate_handler.dart';
+export '../stalemate_paginated_loader/stale_mate_paginated_handler_mixin.dart';
 
 part '../stalemate_paginated_loader/stalemate_paginated_loader.dart';
 
-/// Handles the loading and syncing of data from local and remote sources
-///
-/// This class is used to load data from local and remote sources.
-/// It can be used to load data from a single source, or from both local and remote sources.
-/// This data loader makes no assumptions about the data that is being loaded, nor the
-/// sources that are being used.
+/// A loader that loads data from its [StaleMateHandler] and streams it through a [BehaviorSubject]
 ///
 /// The data loader registers itself in the [StaleMateRegistry] when it is created
 /// and unregisters itself when it is cleared.
 ///
-/// How to implement:
-/// - Extend this class with the data type(<T>) that you want to load data for
-/// - Override the methods that are needed for your use case.
-/// - If you want to get remote data, override [getRemoteData]
-///     - The method should return a [Future] that resolves to the data that was loaded remotely
-///     - If the data could not be loaded, throw an exception, the loader will handle it
-///       by keeping the old data or adding the error to the data stream, depending on if
-///       the value of the [showLocalDataOnError].
-/// - If you want to get local data, override [getLocalData]
-///   - The method should return a [Future] that resolves to the data that was loaded locally
-///   - If the data could not be loaded, throw an exception, the loader will ignore it and try
-///     to load the data remotely.
-/// - If you want to store local data, override [storeLocalData]
-///     - The method receives the data that should be stored locally
-///     - The method should return a [Future] that resolves when the data has been stored
-/// - If you want to remove local data, override [removeLocalData]
-///    - The method receives the data that should be removed locally
-///    - The method should return a [Future] that resolves when the data has been removed
+/// The loader supports manual refresh and automatic refresh.
 ///
-/// Usecases:
-/// - Remote only: For data that is only loaded from remote sources and never stored locally
-///     - Just implement [getRemoteData]
-/// - Local only: For data that is only loaded from local sources and never stored remotely
-///    - Usually implement [getLocalData], [storeLocalData] and [removeLocalData]
-///    - You can use the [addData] method on the loader to add data to the data stream and it will be stored
-///     locally automatically using the [storeLocalData] method
-/// - Local and remote: For data that is loaded from remote sources, but also stored locally for offline use, faster startup etc.
-///     - Usually implement [getRemoteData], [getLocalData], [storeLocalData] and [removeLocalData]
-///
-/// Example:
-/// ```dart
-/// class MyDataLoader extends StaleMateLoader<List<MyData>> {
-///  final LocalDataSource _localDataSource;
-///  final RemoteDataSource _remoteDataSource;
-///
-///  MyDataLoader({
-///    required this.localDataSource,
-///    required this.remoteDataSource,
-///  }) : super(emptyValue: []);
-///
-///  @override
-///  Future<List<MyData>> getRemoteData() async {
-///    // Load the data from the remote data source
-///    return _remoteDataSource.getData();
-///  }
-///
-///  @override
-///  Future<List<MyData>> getLocalData() async {
-///    // Load the data from the local data source
-///    return _localDataSource.getData();
-///  }
-///
-///  @override
-///  Future<void> storeLocalData(List<MyData> data) async {
-///    // Store the data in the local data source
-///    return _localDataSource.storeData(data);
-///  }
-///
-///  @override
-///  Future<void> removeLocalData(List<MyData> data) async {
-///    // Remove the data from the local data source
-///    return _localDataSource.removeData(data);
-///  }
-/// }
-/// ```
-abstract class StaleMateLoader<T> {
+/// To enable automatic refresh, provide a [StaleMateRefreshConfig] to the loader.
+class StaleMateLoader<T, HandlerType extends StaleMateHandler<T>> {
+  /// The handler that will be used to handle the data
+  final HandlerType _handler;
+
   /// Logger instance to be used by the data loader
   late Logger _logger;
-
-  /// The empty value that will be used to seed the stream
-  ///
-  /// For arrays this is usually an empty array, for strings an empty string,
-  /// for nullable types this is usually null, etc.
-  final T emptyValue;
 
   /// Whether or not the data should be updated when the data loader is initialized
   ///
@@ -120,6 +54,7 @@ abstract class StaleMateLoader<T> {
   /// The refresher that will be used to refresh the data
   late final StaleMateRefresher<T> _refresher;
 
+  /// Used to manage the state of the loader
   late final StaleMateStateManager _stateManager;
 
   /// Creates a new data loader
@@ -128,24 +63,24 @@ abstract class StaleMateLoader<T> {
   /// and unregisters itself when it is cleared.
   ///
   /// Arguments:
-  /// - [emptyValue]: The empty value that will be used to determine if the data is empty
-  ///     -  For arrays this is usually an empty array, for strings an empty string,
-  ///       for nullable types this is usually null, etc.
-  /// - [updateOnInit]: Whether or not the data should be updated when the data loader is initialized
+  /// - [updateOnInit] : Whether or not the data should be updated from remote when the data loader is initialized
   ///    - Defaults to true
-  /// - [showLocalDataOnError]: Whether or not the local data should be shown when an error occurs
+  ///    - Has no effect if the handler is [LocalOnlyStaleMateHandler] or [RemoteOnlyStaleMateHandler]
+  /// - [showLocalDataOnError] : Whether or not the local data should be shown when an error occurs
   ///   - Defaults to true
-  /// - [refreshConfig]: The refresh config that will be used to automatically refresh the data
+  ///   - Has no effect if the handler is [LocalOnlyStaleMateHandler] or [RemoteOnlyStaleMateHandler]
+  /// - [refreshConfig] : The refresh config that will be used to automatically refresh the data
   ///     - If this is not provided, the data will not be refreshed automatically
-  /// - [logLevel]: Log level that will be used for this data loader
+  ///     - Manual refresh is always supported by calling [refresh]
+  /// - [logLevel] : Log level that will be used for this data loader
   ///    - Defaults to [StaleMateLogLevel.none]
   StaleMateLoader({
-    required this.emptyValue,
+    required HandlerType handler,
     this.updateOnInit = true,
     this.showLocalDataOnError = true,
     StaleMateRefreshConfig? refreshConfig,
     StaleMateLogLevel? logLevel,
-  }) {
+  }) : _handler = handler {
     // Initialize the logger
     setLogLevel(logLevel ?? StaleMateRegistry.instance.defaultLogLevel);
 
@@ -156,6 +91,7 @@ abstract class StaleMateLoader<T> {
 
     // Initialize the subject and the refresher
     _subject = BehaviorSubject();
+
     // Initialize the refresher
     _refresher = StaleMateRefresher(
       refreshConfig: refreshConfig,
@@ -177,13 +113,28 @@ abstract class StaleMateLoader<T> {
   /// Returns the current value of the data
   ///
   /// This value will be updated automatically when the data is refreshed.
-  /// If the data is not available yet, the [emptyValue] will be returned.
-  T get value => _subject.valueOrNull ?? emptyValue;
+  /// If the data is not available yet, the [StaleMateHandler.emptyValue] will be returned.
+  T get value => _subject.valueOrNull ?? _handler.emptyValue;
 
   /// Whether the data stream is currently empty
   ///
   /// This returns true if the data stream is empty or if the data stream is not available yet.
-  bool get isEmpty => value == emptyValue;
+  bool get isEmpty {
+    final emptyValue = _handler.emptyValue;
+    if (emptyValue is List) {
+      return listEquals(value as List, emptyValue);
+    }
+
+    if (emptyValue is Map) {
+      return mapEquals(value as Map, emptyValue);
+    }
+
+    if (emptyValue is Set) {
+      return setEquals(value as Set, emptyValue);
+    }
+
+    return value == _handler.emptyValue;
+  }
 
   /// Indicates what the current state of the data loader is
   StaleMateLoaderState get state => _stateManager.state;
@@ -206,98 +157,6 @@ abstract class StaleMateLoader<T> {
   /// - [listener] : The listener that will be removed
   void removeStateListener(StateListener listener) {
     _stateManager.removeListener(listener);
-  }
-
-  /// Retrieves the data from the local source
-  ///
-  /// **Override this method to implement local data retrieval**
-  ///
-  /// This method will be called when local data is requested.
-  ///
-  /// How to implement:
-  /// - Retrieve the data from wherever it is stored locally
-  /// - Return the local data
-  /// - If the local data is empty, return the [emptyValue]
-  /// - If there is an error retrieving the local data, throw the error
-  ///
-  /// Example:
-  /// ```dart
-  /// @override
-  /// Future<List<MyData>> getLocalData() async {
-  ///  // Load the data from the local data source
-  ///  return _localDataSource.getData();
-  /// }
-  /// ```
-  Future<T> getLocalData() async {
-    return value;
-  }
-
-  /// Retrieves the data from the remote source
-  ///
-  /// **Override this method to implement remote data retrieval**
-  ///
-  /// This method will be called when remote data is requested.
-  ///
-  /// How to implement:
-  /// - Retrieve the data from the remote source
-  /// - Return the remote data
-  /// - If the remote data is empty, return the [emptyValue]
-  /// - If there is an error retrieving the remote data, throw the error
-  ///
-  /// Example:
-  /// ```dart
-  /// @override
-  /// Future<List<MyData>> getRemoteData() async {
-  ///   // Load the data from the remote data source
-  ///   return _remoteDataSource.getData();
-  /// }
-  /// ```
-  Future<T> getRemoteData() async {
-    return value;
-  }
-
-  /// Stores the data in the local source
-  ///
-  /// **Override this method to implement local data storage**
-  ///
-  /// This method will be called when the data should be stored locally.
-  ///
-  /// How to implement:
-  /// - Store the data in the local data source
-  /// - If there is an error storing the data, throw the error
-  ///
-  /// Example:
-  /// ```dart
-  /// @override
-  /// Future<void> storeLocalData(List<MyData> data) async {
-  ///   // Store the data in the local data source
-  ///   await _localDataSource.storeData(data);
-  /// }
-  /// ```
-  Future<void> storeLocalData(T data) async {
-    // Do nothing
-  }
-
-  /// Removes the data from the local source
-  ///
-  /// **Override this method to implement local data removal**
-  ///
-  /// This method will be called when the data should be removed from the local source.
-  ///
-  /// How to implement:
-  /// - Remove the data from the local data source
-  /// - If there is an error removing the data, throw the error
-  ///
-  /// Example:
-  /// ```dart
-  /// @override
-  /// Future<void> removeLocalData() async {
-  ///   // Remove the data from the local data source
-  ///   await _localDataSource.removeData();
-  /// }
-  /// ```
-  Future<void> removeLocalData() async {
-    // Do nothing
   }
 
   /// Adds an error to the data stream
@@ -337,16 +196,18 @@ abstract class StaleMateLoader<T> {
   ///  // New data available in the stream
   /// ```
   Future<void> addData(T data) async {
-    _logger.d('Added data of type ${data.runtimeType} to stream');
+    _logger.d('Adding data to stream...');
+    _logger.d(data);
     _subject.add(data);
     try {
-      _logger.i('Storing local data of type ${data.runtimeType}...');
-      _logger.d('Local data to store:');
-      _logger.d(data);
-      await storeLocalData(data);
+      await _handler.storeLocalData(data);
       _logger.d('Local data stored successfully');
     } catch (error, stackTrace) {
-      _logger.e('Failed to store local data', error, stackTrace);
+      if (error is NotSupportedException) {
+        _logger.d('Local storage not supported, skipping storing local data');
+      } else {
+        _logger.e('Failed to store local data', error, stackTrace);
+      }
     }
   }
 
@@ -354,8 +215,7 @@ abstract class StaleMateLoader<T> {
   ///
   /// - If [showLocalDataOnError] is true, the error will only be added to the stream if there is no local data available
   /// - If [showLocalDataOnError] is false, the error will always be added to the stream
-  void _onRemoteDataError(Object error) {
-    _logger.e('Failed to load remote data', error, StackTrace.current);
+  void _onRemoteDataError(Object error, StackTrace stackTrace) {
     if (!showLocalDataOnError) {
       _logger.d('showLocalDataOnError is true, adding error to stream');
       _addError(error);
@@ -373,14 +233,15 @@ abstract class StaleMateLoader<T> {
   ///
   /// Returns true if local data was loaded, false if not
   Future<T> _loadLocalData() async {
-    final localData = await getLocalData();
+    _logger.i('Loading local data...');
+    final localData = await _handler.getLocalData();
 
-    if (localData != emptyValue) {
-      _subject.add(localData);
-      return localData;
+    if (localData == _handler.emptyValue) {
+      throw NoLocalDataException('Retrieved local data is empty');
     }
 
-    throw NoLocalDataException('Retrieved local data is empty');
+    _subject.add(localData);
+    return localData;
   }
 
   /// Loads remote data and adds it to the stream
@@ -391,14 +252,27 @@ abstract class StaleMateLoader<T> {
   Future<T> _loadRemoteData() async {
     try {
       _logger.i('Loading remote data...');
-      final remoteData = await getRemoteData();
+      final remoteData = await _handler.getRemoteData();
       _logger.d('Remote data loaded');
       _logger.d(remoteData);
       await addData(remoteData);
       return remoteData;
     } catch (error, stackTrace) {
-      _logger.e('Failed to load remote data', error, stackTrace);
-      _onRemoteDataError(error);
+      if (error is NotSupportedException) {
+        _logger.i('Remote data not supported, skipping remote data load');
+        _stateManager.setRemoteState(
+          StaleMateStatus.idle,
+        );
+      } else {
+        _logger.e('Failed to load remote data', error, stackTrace);
+
+        _onRemoteDataError(error, stackTrace);
+
+        _stateManager.setRemoteState(
+          StaleMateStatus.error,
+          error: error,
+        );
+      }
 
       rethrow;
     }
@@ -409,6 +283,7 @@ abstract class StaleMateLoader<T> {
   /// - Loads local data
   /// - If [updateOnInit] is true or there is no local data available, loads remote data
   Future<void> initialize() async {
+    _logger.i('Initializing loader...');
     _stateManager.setLocalState(StaleMateStatus.loading);
 
     try {
@@ -416,18 +291,26 @@ abstract class StaleMateLoader<T> {
 
       _stateManager.setLocalState(StaleMateStatus.loaded);
 
+      _logger.d('Local data loaded');
       _logger.d(localData);
     } catch (error, stackTrace) {
-      _stateManager.setLocalState(
-        StaleMateStatus.error,
-        error: error,
-      );
+      if (error is NotSupportedException) {
+        _logger.i('Local storage not supported, skipping local data load');
+        _stateManager.setLocalState(
+          StaleMateStatus.idle,
+        );
+      } else {
+        _stateManager.setLocalState(
+          StaleMateStatus.error,
+          error: error,
+        );
 
-      _logger.e(
-        'Failed to load local data',
-        error,
-        stackTrace,
-      );
+        _logger.e(
+          'Failed to load local data',
+          error,
+          stackTrace,
+        );
+      }
     }
 
     // Load remote data if there is no local data available or updateOnInit is true
@@ -451,8 +334,6 @@ abstract class StaleMateLoader<T> {
 
       // Successful load sets the state to loaded with remote data
       if (refreshResult.isSuccess) {
-        _logger.i('Got remote data after initialization');
-
         _stateManager.setRemoteState(
           StaleMateStatus.loaded,
           fetchReason: StaleMateFetchReason.initial,
@@ -532,8 +413,16 @@ abstract class StaleMateLoader<T> {
   /// - Adds empty value to stream
   Future<void> reset() async {
     _logger.i('Resetting data...');
-    await removeLocalData();
-    _subject.add(emptyValue);
+    try {
+      await _handler.removeLocalData();
+    } catch (error, stackTrace) {
+      if (error is NotSupportedException) {
+        _logger.i('Local storage not supported, skipping local data reset');
+      } else {
+        _logger.e('Failed to reset local data', error, stackTrace);
+      }
+    }
+    _subject.add(_handler.emptyValue);
     _stateManager.reset();
   }
 
@@ -551,7 +440,8 @@ abstract class StaleMateLoader<T> {
     _logger = Logger(
       level: staleMateLogLevelToLevel(logLevel),
       printer: TaggedLoggingPrinter(
-        tag: runtimeType.toString(),
+        // Use the runtime type of the handler as the tag
+        tag: _handler.runtimeType.toString(),
         methodCount: logLevel == StaleMateLogLevel.debug ? 2 : 0,
         printTime: logLevel == StaleMateLogLevel.debug,
         colors: false,
@@ -566,7 +456,7 @@ abstract class StaleMateLoader<T> {
   /// - Disposes the refresher
   /// - Unregisters the loader from the registry
   close() {
-    _logger.d('Closing loader');
+    _logger.i('Closing loader');
     _subject.close();
     _refresher.dispose();
     _logger.d('Unregistering from registry');

--- a/lib/src/stalemate_paginated_loader/stale_mate_paginated_handler_mixin.dart
+++ b/lib/src/stalemate_paginated_loader/stale_mate_paginated_handler_mixin.dart
@@ -43,7 +43,7 @@ import 'stalemate_pagination_config.dart';
 ///   }
 /// }
 /// ```
-mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
+mixin PaginatedHandlerMixin<ListItemType> on StaleMateHandler<List<ListItemType>> {
   /// Pagination config used to load the data in pages
   /// 
   /// This is set automatically by the [StaleMatePaginatedLoader]
@@ -53,7 +53,7 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
   /// - [StaleMatePagePagination]
   /// - [StaleMateOffsetLimitPagination]
   /// - [StaleMateCursorPagination]
-  late StaleMatePaginationConfig<T> paginationConfig;
+  late StaleMatePaginationConfig<ListItemType> paginationConfig;
 
   /// Sets the pagination config
   ///
@@ -64,14 +64,14 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
   /// - [StaleMatePagePagination]
   /// - [StaleMateOffsetLimitPagination]
   /// - [StaleMateCursorPagination]
-  setPaginationConfig(StaleMatePaginationConfig<T> paginationConfig) {
+  setPaginationConfig(StaleMatePaginationConfig<ListItemType> paginationConfig) {
     this.paginationConfig = paginationConfig;
   }
 
   /// Holds the fetch more operation
   ///
   /// This is used to cancel the fetch more operation if needed
-  CancelableOperation<List<T>?>? _fetchMoreOperation;
+  CancelableOperation<List<ListItemType>?>? _fetchMoreOperation;
 
   /// Cancels the fetch more operation if it's in progress
   ///
@@ -93,10 +93,10 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
   /// which handles merging the data and setting the [StaleMatePaginationConfig.canFetchMore] flag
   ///
   /// Returns the page of data based on the [paginationParams]
-  Future<List<T>> getRemotePaginatedData(Map<String, dynamic> paginationParams);
+  Future<List<ListItemType>> getRemotePaginatedData(Map<String, dynamic> paginationParams);
 
   @override
-  Future<List<T>> getRemoteData() async {
+  Future<List<ListItemType>> getRemoteData() async {
     cancelFetchMore();
 
     // Get remote data is only called on initial loading and refresh
@@ -116,8 +116,8 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
 
   bool get canFetchMore => paginationConfig.canFetchMore;
 
-  Future<StaleMateFetchMoreResult<T>> fetchNextPage(
-      List<T> previousData) async {
+  Future<StaleMateFetchMoreResult<ListItemType>> fetchNextPage(
+      List<ListItemType> previousData) async {
     final fetchMoreInitiatedAt = DateTime.now();
     if (paginationConfig.canFetchMore) {
       // Retreive the next query params from the pagination config
@@ -141,7 +141,7 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
         // Other errors will throw an exception
         // Empty respones will be an empty list
         if (newData == null) {
-          return StaleMateFetchMoreResult<T>.cancelled(
+          return StaleMateFetchMoreResult<ListItemType>.cancelled(
             fetchMoreInitiatedAt: fetchMoreInitiatedAt,
             queryParams: queryParams,
           );
@@ -154,7 +154,7 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
 
         // If we can fetch more data, return more data available
         if (paginationConfig.canFetchMore) {
-          final fetchMoreResult = StaleMateFetchMoreResult<T>.moreDataAvailable(
+          final fetchMoreResult = StaleMateFetchMoreResult<ListItemType>.moreDataAvailable(
             fetchMoreInitiatedAt: fetchMoreInitiatedAt,
             queryParams: queryParams,
             newData: newData,
@@ -165,7 +165,7 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
         }
 
         // If we can't fetch more data, return done
-        final fetchMoreResult = StaleMateFetchMoreResult<T>.done(
+        final fetchMoreResult = StaleMateFetchMoreResult<ListItemType>.done(
           fetchMoreInitiatedAt: fetchMoreInitiatedAt,
           queryParams: queryParams,
           newData: newData,
@@ -174,7 +174,7 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
 
         return fetchMoreResult;
       } catch (error) {
-        return StaleMateFetchMoreResult<T>.failure(
+        return StaleMateFetchMoreResult<ListItemType>.failure(
           fetchMoreInitiatedAt: fetchMoreInitiatedAt,
           queryParams: queryParams,
           error: error,
@@ -187,7 +187,7 @@ mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
       // We have no new data since no fetch more was initiated, so we return an empty list
       // We also return the fetchMoreInitiatedAt and fetchMoreFinishedAt times since the user would
       // expect those values to be set when the status is done
-      return StaleMateFetchMoreResult<T>.done(
+      return StaleMateFetchMoreResult<ListItemType>.done(
         fetchMoreInitiatedAt: DateTime.now(),
         queryParams: paginationConfig.getQueryParams(
           previousData.length,

--- a/lib/src/stalemate_paginated_loader/stale_mate_paginated_handler_mixin.dart
+++ b/lib/src/stalemate_paginated_loader/stale_mate_paginated_handler_mixin.dart
@@ -1,0 +1,206 @@
+import 'package:async/async.dart';
+
+import '../stalemate_loader/stalemate_loader.dart';
+import 'stale_mate_fetch_more_result.dart';
+import 'stalemate_pagination_config.dart';
+
+/// A mixin that can be used to enable pagination in a [StaleMateHandler]
+/// 
+/// This mixin is used by the [StaleMatePaginatedLoader] class
+/// 
+/// When used, instead of overriding the [StaleMateHandler.getRemoteData] method,
+/// the [PaginatedHandlerMixin.getRemotePaginatedData] method should be overridden
+/// to provide the data retrieval from the server
+/// 
+/// Example: 
+/// ```dart
+/// class MyPaginatedStaleMateHandler extends StaleMateHandler<List<MyData>> with PaginatedHandlerMixin<MyData> {
+///  @override
+///  List<MyData> get emptyValue => [];
+/// 
+///  @override
+///  Future<List<MyData>> getLocalData() async {
+///    // Load the data from the local data source
+///    return _localDataSource.getData();
+///   }
+/// 
+///   @override
+///   Future<List<MyData>> getRemotePaginatedData(Map<String, dynamic> paginationParams) async {
+///     // Load the data from the remote data source
+///     return _remoteDataSource.getData(paginationParams);
+///   }
+/// 
+///   @override
+///   Future<void> storeLocalData(List<MyData> data) async {
+///     // Store the data in the local data source
+///     await _localDataSource.storeData(data);
+///   }
+/// 
+///   @override
+///   Future<void> removeLocalData() async {
+///     // Remove the data from the local data source
+///     await _localDataSource.removeData();
+///   }
+/// }
+/// ```
+mixin PaginatedHandlerMixin<T> on StaleMateHandler<List<T>> {
+  /// Pagination config used to load the data in pages
+  /// 
+  /// This is set automatically by the [StaleMatePaginatedLoader]
+  ///
+  /// See also:
+  /// - [StaleMatePaginationConfig]
+  /// - [StaleMatePagePagination]
+  /// - [StaleMateOffsetLimitPagination]
+  /// - [StaleMateCursorPagination]
+  late StaleMatePaginationConfig<T> paginationConfig;
+
+  /// Sets the pagination config
+  ///
+  /// This method is called from the constructor of the [StaleMatePaginatedLoader]
+  ///
+  /// See also:
+  /// - [StaleMatePaginationConfig]
+  /// - [StaleMatePagePagination]
+  /// - [StaleMateOffsetLimitPagination]
+  /// - [StaleMateCursorPagination]
+  setPaginationConfig(StaleMatePaginationConfig<T> paginationConfig) {
+    this.paginationConfig = paginationConfig;
+  }
+
+  /// Holds the fetch more operation
+  ///
+  /// This is used to cancel the fetch more operation if needed
+  CancelableOperation<List<T>?>? _fetchMoreOperation;
+
+  /// Cancels the fetch more operation if it's in progress
+  ///
+  /// Called when the loader is refreshed, initialized or disposed
+  cancelFetchMore() {
+    if (_fetchMoreOperation != null) {
+      _fetchMoreOperation?.cancel();
+      _fetchMoreOperation = null;
+    }
+  }
+
+  /// This method is called when the loader needs to fetch the next page of data from the server
+  ///
+  /// The [paginationParams] argument contains the params needed to fetch the next page of data
+  ///
+  /// Override this method to fetch the next page of data from the server based on the [paginationParams]
+  ///
+  /// The data returned from this method will be passed through the [StaleMatePaginationConfig.onReceivedData] method
+  /// which handles merging the data and setting the [StaleMatePaginationConfig.canFetchMore] flag
+  ///
+  /// Returns the page of data based on the [paginationParams]
+  Future<List<T>> getRemotePaginatedData(Map<String, dynamic> paginationParams);
+
+  @override
+  Future<List<T>> getRemoteData() async {
+    cancelFetchMore();
+
+    // Get remote data is only called on initial loading and refresh
+    // In those cases we reset the pagination and get the first page of data
+    paginationConfig.reset();
+    final queryParams = paginationConfig.getQueryParams(
+      0,
+      null,
+    );
+
+    // The data returned from the server is passed through the [onReceivedData] method
+    // which handles merging the data and setting the [canFetchMore] flag
+    final data = await getRemotePaginatedData(queryParams);
+
+    return paginationConfig.onReceivedData(data, []);
+  }
+
+  bool get canFetchMore => paginationConfig.canFetchMore;
+
+  Future<StaleMateFetchMoreResult<T>> fetchNextPage(
+      List<T> previousData) async {
+    final fetchMoreInitiatedAt = DateTime.now();
+    if (paginationConfig.canFetchMore) {
+      // Retreive the next query params from the pagination config
+      final queryParams = paginationConfig.getQueryParams(
+        previousData.length,
+        previousData.last,
+      );
+
+      _fetchMoreOperation = CancelableOperation.fromFuture(
+        getRemotePaginatedData(queryParams),
+      );
+
+      try {
+        // Get the new data from the implemented getRemotePaginatedData method
+        final newData = await _fetchMoreOperation!.valueOrCancellation(null);
+
+        // Reset the fetch more operation
+        _fetchMoreOperation = null;
+
+        // Null is used to signal that the fetch more operation was cancelled
+        // Other errors will throw an exception
+        // Empty respones will be an empty list
+        if (newData == null) {
+          return StaleMateFetchMoreResult<T>.cancelled(
+            fetchMoreInitiatedAt: fetchMoreInitiatedAt,
+            queryParams: queryParams,
+          );
+        }
+
+        // The data returned from the server is passed through the [onReceivedData] method
+        // which handles merging the data and setting the [canFetchMore] flag
+        final mergedData =
+            paginationConfig.onReceivedData(newData, previousData);
+
+        // If we can fetch more data, return more data available
+        if (paginationConfig.canFetchMore) {
+          final fetchMoreResult = StaleMateFetchMoreResult<T>.moreDataAvailable(
+            fetchMoreInitiatedAt: fetchMoreInitiatedAt,
+            queryParams: queryParams,
+            newData: newData,
+            mergedData: mergedData,
+          );
+
+          return fetchMoreResult;
+        }
+
+        // If we can't fetch more data, return done
+        final fetchMoreResult = StaleMateFetchMoreResult<T>.done(
+          fetchMoreInitiatedAt: fetchMoreInitiatedAt,
+          queryParams: queryParams,
+          newData: newData,
+          mergedData: mergedData,
+        );
+
+        return fetchMoreResult;
+      } catch (error) {
+        return StaleMateFetchMoreResult<T>.failure(
+          fetchMoreInitiatedAt: fetchMoreInitiatedAt,
+          queryParams: queryParams,
+          error: error,
+        );
+      }
+    } else {
+      // We were done fetching more data before this request
+      // This can happen if the user calls fetch more after the last page of data has been fetched
+      // We include the fetch more parameters and the merged data in the result
+      // We have no new data since no fetch more was initiated, so we return an empty list
+      // We also return the fetchMoreInitiatedAt and fetchMoreFinishedAt times since the user would
+      // expect those values to be set when the status is done
+      return StaleMateFetchMoreResult<T>.done(
+        fetchMoreInitiatedAt: DateTime.now(),
+        queryParams: paginationConfig.getQueryParams(
+          previousData.length,
+          previousData.last,
+        ),
+        newData: [],
+        mergedData: previousData,
+      );
+    }
+  }
+
+  reset() {
+    cancelFetchMore();
+    paginationConfig.reset();
+  }
+}

--- a/lib/src/stalemate_paginated_loader/stalemate_paginated_loader.dart
+++ b/lib/src/stalemate_paginated_loader/stalemate_paginated_loader.dart
@@ -5,7 +5,10 @@ part of '../stalemate_loader/stalemate_loader.dart';
 /// This loader is useful when you have data that needs to be loaded in pages.
 ///
 /// The [StaleMatePaginatedLoader] supports everything that the [StaleMateLoader] supports,
-/// and adds the ability to load paginated data
+/// and adds the ability to load paginated data.
+///
+/// - In contrast to the base [StaleMateLoader], the [StaleMatePaginatedLoader] only supports lists,
+///  and takes in T as a data type, where T is the type of the list items.
 ///
 /// Additions to base [StaleMateLoader]:
 /// - **handler** must use [PaginatedHandlerMixin]
@@ -44,8 +47,9 @@ part of '../stalemate_loader/stalemate_loader.dart';
 ///   },
 ///);
 ///```
-class StaleMatePaginatedLoader<T, HandlerType extends PaginatedHandlerMixin<T>>
-    extends StaleMateLoader<List<T>, HandlerType> {
+class StaleMatePaginatedLoader<ListItemType,
+        HandlerType extends PaginatedHandlerMixin<ListItemType>>
+    extends StaleMateLoader<List<ListItemType>, HandlerType> {
   /// Create a new [StaleMatePaginatedLoader] instance
   ///
   /// Used to load data in pages.
@@ -58,7 +62,7 @@ class StaleMatePaginatedLoader<T, HandlerType extends PaginatedHandlerMixin<T>>
   /// - [refreshConfig] : Refresh config used to refresh the data
   /// - [logLevel] : Log level used to log the loader events
   StaleMatePaginatedLoader({
-    required StaleMatePaginationConfig<T> paginationConfig,
+    required StaleMatePaginationConfig<ListItemType> paginationConfig,
     required HandlerType handler,
     super.updateOnInit,
     super.showLocalDataOnError,
@@ -125,11 +129,11 @@ class StaleMatePaginatedLoader<T, HandlerType extends PaginatedHandlerMixin<T>>
   ///   },
   /// );
   /// ```
-  Future<StaleMateFetchMoreResult<T>> fetchMore() async {
+  Future<StaleMateFetchMoreResult<ListItemType>> fetchMore() async {
     // If we are already fetching data, return already fetching
     if (state.loading) {
       _logger.i('Could not fetch more. Already fetching data');
-      return StaleMateFetchMoreResult<T>.alreadyFetching();
+      return StaleMateFetchMoreResult<ListItemType>.alreadyFetching();
     }
 
     _stateManager.setRemoteState(

--- a/lib/stalemate.dart
+++ b/lib/stalemate.dart
@@ -93,9 +93,9 @@ class StaleMate {
   ///
   /// If you want to:
   /// - Get all loaders, use [getAllLoaders].
-  /// - Get the first loader of a specific type, use [getFirstLoader].
-  static List<StaleMateLoader> getLoaders<T extends StaleMateLoader>() =>
-      StaleMateRegistry.instance.getLoaders<T>();
+  static List<StaleMateLoader<T, R>>
+      getLoadersWithHandler<T, R extends StaleMateHandler<T>>() =>
+          StaleMateRegistry.instance.getLoadersWithHandler<T, R>();
 
   /// Refreshes all registered loaders of the given type.
   ///
@@ -113,9 +113,9 @@ class StaleMate {
   /// See also:
   /// - [StaleMateRefreshResult] for more information about the result of a refresh
   /// - [StaleMateLoader.refresh] for more information about refreshing a loader
-  static Future<List<StaleMateRefreshResult>>
-      refreshLoaders<T extends StaleMateLoader>() =>
-          StaleMateRegistry.instance.refreshLoaders<T>();
+  static Future<List<StaleMateRefreshResult<T>>>
+      refreshLoadersWithHandler<T, R extends StaleMateHandler<T>>() =>
+          StaleMateRegistry.instance.refreshLoadersWithHandler<T, R>();
 
   /// Resets all loaders registered of the given type.
   ///
@@ -128,8 +128,9 @@ class StaleMate {
   /// - Reset all loaders, use [resetAllLoaders].
   /// - Reset the first loader of a specific type, use [resetFirstLoader].
   /// - Reset an individual loader, use [StaleMateLoader.reset].
-  static Future<void> resetLoaders<T extends StaleMateLoader>() =>
-      StaleMateRegistry.instance.resetLoaders<T>();
+  static Future<void>
+      resetLoadersWithHandler<T, R extends StaleMateHandler<T>>() =>
+          StaleMateRegistry.instance.resetLoadersWithHandler<T, R>();
 
   /// Whether a loader of the given type is registered.
   ///
@@ -137,57 +138,8 @@ class StaleMate {
   /// Returns false if no loaders are registered.
   ///
   /// If multiple loaders are found, true is returned.
-  static bool hasLoader<T extends StaleMateLoader>() =>
-      StaleMateRegistry.instance.hasLoader<T>();
-
-  /// Returns the first registered loader of the given type.
-  /// Returns null if no loaders are found.
-  ///
-  /// If you want to:
-  /// - Get all loaders, use [getAllLoaders].
-  /// - Get all loaders of a specific type, use [getLoaders].
-  static StaleMateLoader? getFirstLoader<T extends StaleMateLoader>() =>
-      StaleMateRegistry.instance.getFirstLoader<T>();
-
-  /// Refreshes the first registered loader of the given type.
-  ///
-  /// This will call the loader's [StaleMateLoader.refresh] method.
-  ///
-  /// Returns the [StaleMateRefreshResult] for the loader,
-  /// indicating whether the loader was refreshed successfully.
-  ///
-  /// Will throw an assertion error if no loader is found,
-  /// please use [hasLoader] to check if a loader is registered
-  /// before calling this method.
-  ///
-  /// If you want to:
-  /// - Refresh all loaders, use [refreshAllLoaders].
-  /// - Refresh all loaders of a specific type, use [refreshLoaders].
-  /// - Refresh an individual loader, use [StaleMateLoader.refresh].
-  ///
-  /// See also:
-  /// - [StaleMateRefreshResult] for more information about the result of a refresh
-  /// - [StaleMateLoader.refresh] for more information about refreshing a loader
-  static Future<StaleMateRefreshResult>
-      refreshFirstLoader<T extends StaleMateLoader>() =>
-          StaleMateRegistry.instance.refreshFirstLoader<T>();
-
-  /// Resets the first registered loader of the given type.
-  ///
-  /// This will clear all data from the loader
-  /// and call the [StaleMateLoader.removeLocalData] method.
-  ///
-  /// The loader will be reset to its empty value.
-  ///
-  /// Will throw an assertion error if no loader is found,
-  /// please use [hasLoader] to check if a loader is registered
-  ///
-  /// If you want to:
-  /// - Reset all loaders, use [resetAllLoaders].
-  /// - Reset all loaders of a specific type, use [resetLoaders].
-  /// - Reset an individual loader, use [StaleMateLoader.reset].
-  static Future<void> resetFirstLoader<T extends StaleMateLoader>() =>
-      StaleMateRegistry.instance.resetFirstLoader<T>();
+  static bool hasLoaderWithHandler<T, R extends StaleMateHandler<T>>() =>
+      StaleMateRegistry.instance.hasLoaderWithHandler<T, R>();
 
   /// Sets the global log level for all registered StaleMate loaders.
   ///

--- a/lib/stalemate.dart
+++ b/lib/stalemate.dart
@@ -49,8 +49,7 @@ class StaleMate {
   /// Returns an empty list if no loaders are found.
   ///
   /// If you want to:
-  /// - Get all loaders of a specific type, use [getLoaders].
-  /// - Get the first loader of a specific type, use [getFirstLoader].
+  /// - Get all loaders for a specific handler [getLoadersWithHandler].
   static List<StaleMateLoader> getAllLoaders() =>
       StaleMateRegistry.instance.getAllLoaders();
 
@@ -63,8 +62,7 @@ class StaleMate {
   /// Results are returned in the order of when the loaders were registered.
   ///
   /// If you want to:
-  /// - Refresh all loaders of a specific type, use [refreshLoaders].
-  /// - Refresh the first loader of a specific type, use [refreshFirstLoader].
+  /// - Refresh all loaders for a specific handler, use [refreshLoadersWithHandler].
   /// - Refresh an individual loader, use [StaleMateLoader.refresh].
   ///
   /// See also:
@@ -76,13 +74,12 @@ class StaleMate {
   /// Resets all loaders registered with StaleMate.
   ///
   /// This will clear all data from the loaders
-  /// and call their [StaleMateLoader.removeLocalData] method.
+  /// and call the [StaleMateHandler.removeLocalData] on their handler
   ///
   /// The loaders will be reset to their empty value.
   ///
   /// If you want to:
-  /// - Reset all loaders of a specific type, use [resetLoaders].
-  /// - Reset the first loader of a specific type, use [resetFirstLoader].
+  /// - Resetall loaders for a specific handler, use [resetLoadersWithHandler].
   /// - Reset an individual loader, use [StaleMateLoader.reset].
   static Future<void> resetAllLoaders() =>
       StaleMateRegistry.instance.resetAllLoaders();
@@ -107,7 +104,6 @@ class StaleMate {
   ///
   /// If you want to:
   /// - Refresh all loaders, use [refreshAllLoaders].
-  /// - Refresh the first loader of a specific type, use [refreshFirstLoader].
   /// - Refresh an individual loader, use [StaleMateLoader.refresh].
   ///
   /// See also:
@@ -120,13 +116,12 @@ class StaleMate {
   /// Resets all loaders registered of the given type.
   ///
   /// This will clear all data from the loaders
-  /// and call their [StaleMateLoader.removeLocalData] method.
+  /// and call the [StaleMateHandler.removeLocalData] method on their handler.
   ///
   /// The loaders will be reset to their empty value.
   ///
   /// If you want to:
   /// - Reset all loaders, use [resetAllLoaders].
-  /// - Reset the first loader of a specific type, use [resetFirstLoader].
   /// - Reset an individual loader, use [StaleMateLoader.reset].
   static Future<void>
       resetLoadersWithHandler<T, R extends StaleMateHandler<T>>() =>

--- a/test/mocks/mock_empty_value_handlers.dart
+++ b/test/mocks/mock_empty_value_handlers.dart
@@ -1,0 +1,126 @@
+import 'package:stalemate/stalemate.dart';
+
+class StringEmptyValueHandler extends RemoteOnlyStaleMateHandler<String> {
+  @override
+  String get emptyValue => '';
+
+  @override
+  Future<String> getRemoteData() async {
+    return 'remote data';
+  }
+}
+
+class IntEmptyValueHandler extends RemoteOnlyStaleMateHandler<int> {
+  @override
+  int get emptyValue => -1;
+
+  @override
+  Future<int> getRemoteData() async {
+    return 1;
+  }
+}
+
+class DoubleEmptyValueHandler extends RemoteOnlyStaleMateHandler<double> {
+  @override
+  double get emptyValue => -1.0;
+
+  @override
+  Future<double> getRemoteData() async {
+    return 1.0;
+  }
+}
+
+class BoolEmptyValueHandler extends RemoteOnlyStaleMateHandler<bool> {
+  @override
+  bool get emptyValue => false;
+
+  @override
+  Future<bool> getRemoteData() async {
+    return true;
+  }
+}
+
+class ListEmptyValueHandler extends RemoteOnlyStaleMateHandler<List> {
+  @override
+  List get emptyValue => [];
+
+  @override
+  Future<List> getRemoteData() async {
+    return [1, 2, 3];
+  }
+}
+
+class MapEmptyValueHandler extends RemoteOnlyStaleMateHandler<Map> {
+  @override
+  Map get emptyValue => {};
+
+  @override
+  Future<Map> getRemoteData() async {
+    return {'key': 'value'};
+  }
+}
+
+class SetEmptyValueHandler extends RemoteOnlyStaleMateHandler<Set> {
+  @override
+  Set get emptyValue => {};
+
+  @override
+  Future<Set> getRemoteData() async {
+    return {1, 2, 3};
+  }
+}
+
+class NullableEmptyValueHandler extends RemoteOnlyStaleMateHandler<String?> {
+  @override
+  String? get emptyValue => null;
+
+  @override
+  Future<String?> getRemoteData() async {
+    return 'remote data';
+  }
+}
+
+enum TestEnum { empty, one, two }
+
+class EnumEmptyValueHandler extends RemoteOnlyStaleMateHandler<TestEnum> {
+  @override
+  TestEnum get emptyValue => TestEnum.empty;
+
+  @override
+  Future<TestEnum> getRemoteData() async {
+    return TestEnum.one;
+  }
+}
+
+class TestClass {
+  final String name;
+  final int age;
+
+  TestClass(this.name, this.age);
+
+  @override
+  String toString() {
+    return 'TestClass{name: $name, age: $age}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TestClass &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          age == other.age;
+
+  @override
+  int get hashCode => name.hashCode ^ age.hashCode;
+}
+
+class CustomClassEmptyValueHandler extends RemoteOnlyStaleMateHandler<TestClass> {
+  @override
+  TestClass get emptyValue => TestClass('', -1);
+
+  @override
+  Future<TestClass> getRemoteData() async {
+    return TestClass('name', 1);
+  }
+}

--- a/test/mocks/mock_string_loader.dart
+++ b/test/mocks/mock_string_loader.dart
@@ -1,0 +1,80 @@
+import 'package:stalemate/stalemate.dart';
+
+class MockStringHandler extends StaleMateHandler<String> {
+  String _localData = 'initial local data';
+
+  bool shouldThrowLocalError = false;
+  bool shouldThrowRemoteError = false;
+  bool shouldThrowWhileStoring = false;
+  bool shouldThrowWhileRemoving = false;
+  int timesUpdatedFromRemote = 0;
+
+  @override
+  String get emptyValue => '';
+
+  @override
+  Future<String> getLocalData() async {
+    if (shouldThrowLocalError) {
+      throw Exception('Failed to fetch local data');
+    }
+    return _localData;
+  }
+
+  @override
+  Future<String> getRemoteData() async {
+    await Future.delayed(const Duration(milliseconds: 10));
+    if (shouldThrowRemoteError) {
+      throw Exception('Failed to fetch remote data');
+    }
+    return 'remote data ${++timesUpdatedFromRemote}';
+  }
+
+  @override
+  Future<void> storeLocalData(String data) async {
+    if (shouldThrowWhileStoring) {
+      throw Exception('Failed to store local data');
+    }
+    _localData = data;
+  }
+
+  @override
+  Future<void> removeLocalData() async {
+    if (shouldThrowWhileRemoving) {
+      throw Exception('Failed to remove local data');
+    }
+    timesUpdatedFromRemote = 0;
+    _localData = '';
+  }
+}
+
+class StringLoader extends StaleMateLoader<String, MockStringHandler> {
+  final MockStringHandler handler;
+
+  clearLocalData() {
+    handler._localData = '';
+  }
+
+  setShouldThrowLocalError(bool shouldThrow) {
+    handler.shouldThrowLocalError = shouldThrow;
+  }
+
+  setShouldThrowRemoteError(bool shouldThrow) {
+    handler.shouldThrowRemoteError = shouldThrow;
+  }
+
+  setShouldThrowWhileStoring(bool shouldThrow) {
+    handler.shouldThrowWhileStoring = shouldThrow;
+  }
+
+  setShouldThrowWhileRemoving(bool shouldThrow) {
+    handler.shouldThrowWhileRemoving = shouldThrow;
+  }
+
+  StringLoader({
+    required this.handler,
+    bool updateOnInit = true,
+  }) : super(
+          handler: handler,
+          updateOnInit: updateOnInit,
+        );
+}

--- a/test/src/stalemate_builder_test.dart
+++ b/test/src/stalemate_builder_test.dart
@@ -2,53 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stalemate/stalemate.dart';
 
-class StringLoader extends StaleMateLoader<String> {
-  String _localData = 'initial local data';
-  bool shouldThrowError = false;
-  int timesUpdatedFromRemote = 0;
-
-  StringLoader({
-    bool updateOnInit = true,
-  }) : super(
-          emptyValue: '',
-          updateOnInit: updateOnInit,
-        );
-
-  @override
-  Future<String> getLocalData() async {
-    return _localData;
-  }
-
-  @override
-  Future<String> getRemoteData() async {
-    await Future.delayed(const Duration(milliseconds: 100));
-    if (shouldThrowError) {
-      throw Exception('Failed to fetch remote data');
-    }
-    return 'remote data ${++timesUpdatedFromRemote}';
-  }
-
-  @override
-  Future<void> storeLocalData(String data) async {
-    _localData = data;
-  }
-
-  @override
-  Future<void> removeLocalData() async {
-    shouldThrowError = false;
-    timesUpdatedFromRemote = 0;
-    _localData = '';
-  }
-}
+import '../mocks/mock_string_loader.dart';
 
 void main() {
   testWidgets('StaleMateBuilder test', (WidgetTester tester) async {
     // Create a StaleMateLoader instance
-    StringLoader loader = StringLoader();
+    StringLoader loader = StringLoader(
+      handler: MockStringHandler(),
+    );
 
     await tester.pumpWidget(
       MaterialApp(
-        home: StaleMateBuilder<String>(
+        home: StaleMateBuilder<String, MockStringHandler>(
           loader: loader,
           builder: (context, data) {
             if (data.isLoading) {
@@ -68,24 +33,24 @@ void main() {
     expect(find.text('Loading'), findsOneWidget);
 
     loader.initialize();
-    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pump(const Duration(milliseconds: 5));
 
     // Should be initial data right after initialization
     expect(find.text('initial local data'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 10));
     expect(find.text('remote data 1'), findsOneWidget);
 
-    loader.reset();
+    await loader.reset();
 
     // Simulate an error
-    loader.shouldThrowError = true;
+    loader.setShouldThrowRemoteError(true);
 
     await tester.pump(const Duration(milliseconds: 10));
     // Trigger a refresh
     loader.refresh();
 
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 15));
     expect(find.text('Error'), findsOneWidget);
   });
 }

--- a/test/src/stalemate_refresher_test.dart
+++ b/test/src/stalemate_refresher_test.dart
@@ -10,11 +10,11 @@ import 'package:stalemate/src/stalemate_refresher/stalemate_refresher.dart';
 import '../mocks/mock_clock.dart';
 import 'stalemate_refresher_test.mocks.dart';
 
-@GenerateMocks([StaleMateRefreshConfig, StaleMateLoader])
+@GenerateMocks([StaleMateRefreshConfig, StaleMateLoader, StaleMateHandler])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockStaleMateLoader<bool> mockDataLoader;
+  late MockStaleMateLoader<bool, MockStaleMateHandler<bool>> mockDataLoader;
   late StalePeriodRefreshConfig refreshConfig;
   late MockClock clock;
   final mockRefreshSuccessResult = StaleMateRefreshResult<bool>.success(
@@ -30,7 +30,7 @@ void main() {
   );
 
   setUp(() {
-    mockDataLoader = MockStaleMateLoader<bool>();
+    mockDataLoader = MockStaleMateLoader<bool, MockStaleMateHandler<bool>>();
     clock = MockClock();
     refreshConfig = StalePeriodRefreshConfig(
       stalePeriod: const Duration(minutes: 5),

--- a/test/src/stalemate_refresher_test.mocks.dart
+++ b/test/src/stalemate_refresher_test.mocks.dart
@@ -5,13 +5,19 @@
 // @dart=2.19
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i2;
+import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i6;
-import 'package:stalemate/src/stalemate_loader/stalemate_loader.dart' as _i5;
+import 'package:mockito/src/dummies.dart' as _i8;
+import 'package:stalemate/src/logging/stalemate_log_level.dart' as _i10;
+import 'package:stalemate/src/stalemate_loader/stalemate_handler.dart' as _i6;
+import 'package:stalemate/src/stalemate_loader/stalemate_loader.dart' as _i7;
+import 'package:stalemate/src/stalemate_loader/stalemate_loader_state.dart'
+    as _i2;
+import 'package:stalemate/src/stalemate_loader/stalemate_state_manager.dart'
+    as _i9;
 import 'package:stalemate/src/stalemate_refresher/stalemate_refresh_config.dart'
-    as _i4;
+    as _i5;
 import 'package:stalemate/src/stalemate_refresher/stalemate_refresh_result.dart'
     as _i3;
 
@@ -36,8 +42,9 @@ class _FakeDuration_0 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakeFuture_1<T1> extends _i1.SmartFake implements _i2.Future<T1> {
-  _FakeFuture_1(
+class _FakeStaleMateLoaderState_1 extends _i1.SmartFake
+    implements _i2.StaleMateLoaderState {
+  _FakeStaleMateLoaderState_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -57,11 +64,21 @@ class _FakeStaleMateRefreshResult_2<T1> extends _i1.SmartFake
         );
 }
 
+class _FakeFuture_3<T1> extends _i1.SmartFake implements _i4.Future<T1> {
+  _FakeFuture_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [StaleMateRefreshConfig].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockStaleMateRefreshConfig extends _i1.Mock
-    implements _i4.StaleMateRefreshConfig {
+    implements _i5.StaleMateRefreshConfig {
   MockStaleMateRefreshConfig() {
     _i1.throwOnMissingStub(this);
   }
@@ -94,20 +111,12 @@ class MockStaleMateRefreshConfig extends _i1.Mock
 /// A class which mocks [StaleMateLoader].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStaleMateLoader<T> extends _i1.Mock
-    implements _i5.StaleMateLoader<T> {
+class MockStaleMateLoader<T, HandlerType extends _i6.StaleMateHandler<T>>
+    extends _i1.Mock implements _i7.StaleMateLoader<T, HandlerType> {
   MockStaleMateLoader() {
     _i1.throwOnMissingStub(this);
   }
 
-  @override
-  T get emptyValue => (super.noSuchMethod(
-        Invocation.getter(#emptyValue),
-        returnValue: _i6.dummyValue<T>(
-          this,
-          Invocation.getter(#emptyValue),
-        ),
-      ) as T);
   @override
   bool get updateOnInit => (super.noSuchMethod(
         Invocation.getter(#updateOnInit),
@@ -119,109 +128,72 @@ class MockStaleMateLoader<T> extends _i1.Mock
         returnValue: false,
       ) as bool);
   @override
-  _i2.Stream<T> get stream => (super.noSuchMethod(
+  _i4.Stream<T> get stream => (super.noSuchMethod(
         Invocation.getter(#stream),
-        returnValue: _i2.Stream<T>.empty(),
-      ) as _i2.Stream<T>);
+        returnValue: _i4.Stream<T>.empty(),
+      ) as _i4.Stream<T>);
   @override
   T get value => (super.noSuchMethod(
         Invocation.getter(#value),
-        returnValue: _i6.dummyValue<T>(
+        returnValue: _i8.dummyValue<T>(
           this,
           Invocation.getter(#value),
         ),
       ) as T);
   @override
-  _i2.Future<T> getLocalData() => (super.noSuchMethod(
-        Invocation.method(
-          #getLocalData,
-          [],
-        ),
-        returnValue: _i6.ifNotNull(
-              _i6.dummyValueOrNull<T>(
-                this,
-                Invocation.method(
-                  #getLocalData,
-                  [],
-                ),
-              ),
-              (T v) => _i2.Future<T>.value(v),
-            ) ??
-            _FakeFuture_1<T>(
-              this,
-              Invocation.method(
-                #getLocalData,
-                [],
-              ),
-            ),
-      ) as _i2.Future<T>);
+  bool get isEmpty => (super.noSuchMethod(
+        Invocation.getter(#isEmpty),
+        returnValue: false,
+      ) as bool);
   @override
-  _i2.Future<T> getRemoteData() => (super.noSuchMethod(
-        Invocation.method(
-          #getRemoteData,
-          [],
+  _i2.StaleMateLoaderState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _FakeStaleMateLoaderState_1(
+          this,
+          Invocation.getter(#state),
         ),
-        returnValue: _i6.ifNotNull(
-              _i6.dummyValueOrNull<T>(
-                this,
-                Invocation.method(
-                  #getRemoteData,
-                  [],
-                ),
-              ),
-              (T v) => _i2.Future<T>.value(v),
-            ) ??
-            _FakeFuture_1<T>(
-              this,
-              Invocation.method(
-                #getRemoteData,
-                [],
-              ),
-            ),
-      ) as _i2.Future<T>);
+      ) as _i2.StaleMateLoaderState);
   @override
-  _i2.Future<void> storeLocalData(T? data) => (super.noSuchMethod(
+  void addStateListener(_i9.StateListener? listener) => super.noSuchMethod(
         Invocation.method(
-          #storeLocalData,
-          [data],
+          #addStateListener,
+          [listener],
         ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+        returnValueForMissingStub: null,
+      );
   @override
-  _i2.Future<void> removeLocalData() => (super.noSuchMethod(
+  void removeStateListener(_i9.StateListener? listener) => super.noSuchMethod(
         Invocation.method(
-          #removeLocalData,
-          [],
+          #removeStateListener,
+          [listener],
         ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+        returnValueForMissingStub: null,
+      );
   @override
-  _i2.Future<void> addData(T? data) => (super.noSuchMethod(
+  _i4.Future<void> addData(T? data) => (super.noSuchMethod(
         Invocation.method(
           #addData,
           [data],
         ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i2.Future<void> initialize() => (super.noSuchMethod(
+  _i4.Future<void> initialize() => (super.noSuchMethod(
         Invocation.method(
           #initialize,
           [],
         ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
-  _i2.Future<_i3.StaleMateRefreshResult<T>> refresh() => (super.noSuchMethod(
+  _i4.Future<_i3.StaleMateRefreshResult<T>> refresh() => (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [],
         ),
-        returnValue: _i2.Future<_i3.StaleMateRefreshResult<T>>.value(
+        returnValue: _i4.Future<_i3.StaleMateRefreshResult<T>>.value(
             _FakeStaleMateRefreshResult_2<T>(
           this,
           Invocation.method(
@@ -229,14 +201,107 @@ class MockStaleMateLoader<T> extends _i1.Mock
             [],
           ),
         )),
-      ) as _i2.Future<_i3.StaleMateRefreshResult<T>>);
+      ) as _i4.Future<_i3.StaleMateRefreshResult<T>>);
   @override
-  _i2.Future<void> reset() => (super.noSuchMethod(
+  _i4.Future<void> reset() => (super.noSuchMethod(
         Invocation.method(
           #reset,
           [],
         ),
-        returnValue: _i2.Future<void>.value(),
-        returnValueForMissingStub: _i2.Future<void>.value(),
-      ) as _i2.Future<void>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  void setLogLevel(_i10.StaleMateLogLevel? logLevel) => super.noSuchMethod(
+        Invocation.method(
+          #setLogLevel,
+          [logLevel],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [StaleMateHandler].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockStaleMateHandler<T> extends _i1.Mock
+    implements _i6.StaleMateHandler<T> {
+  MockStaleMateHandler() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  T get emptyValue => (super.noSuchMethod(
+        Invocation.getter(#emptyValue),
+        returnValue: _i8.dummyValue<T>(
+          this,
+          Invocation.getter(#emptyValue),
+        ),
+      ) as T);
+  @override
+  _i4.Future<T> getLocalData() => (super.noSuchMethod(
+        Invocation.method(
+          #getLocalData,
+          [],
+        ),
+        returnValue: _i8.ifNotNull(
+              _i8.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #getLocalData,
+                  [],
+                ),
+              ),
+              (T v) => _i4.Future<T>.value(v),
+            ) ??
+            _FakeFuture_3<T>(
+              this,
+              Invocation.method(
+                #getLocalData,
+                [],
+              ),
+            ),
+      ) as _i4.Future<T>);
+  @override
+  _i4.Future<T> getRemoteData() => (super.noSuchMethod(
+        Invocation.method(
+          #getRemoteData,
+          [],
+        ),
+        returnValue: _i8.ifNotNull(
+              _i8.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #getRemoteData,
+                  [],
+                ),
+              ),
+              (T v) => _i4.Future<T>.value(v),
+            ) ??
+            _FakeFuture_3<T>(
+              this,
+              Invocation.method(
+                #getRemoteData,
+                [],
+              ),
+            ),
+      ) as _i4.Future<T>);
+  @override
+  _i4.Future<void> storeLocalData(T? data) => (super.noSuchMethod(
+        Invocation.method(
+          #storeLocalData,
+          [data],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
+  _i4.Future<void> removeLocalData() => (super.noSuchMethod(
+        Invocation.method(
+          #removeLocalData,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/test/src/stalemate_registry_test.mocks.dart
+++ b/test/src/stalemate_registry_test.mocks.dart
@@ -5,13 +5,16 @@
 // @dart=2.19
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:stalemate/src/stalemate_loader/stalemate_loader.dart' as _i2;
+import 'package:stalemate/src/stalemate_loader/stalemate_state_manager.dart'
+    as _i6;
 import 'package:stalemate/src/stalemate_refresher/stalemate_refresh_result.dart'
-    as _i2;
+    as _i3;
 
-import 'stalemate_registry_test.dart' as _i3;
+import 'stalemate_registry_test.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -24,9 +27,9 @@ import 'stalemate_registry_test.dart' as _i3;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeStaleMateRefreshResult_0<T> extends _i1.SmartFake
-    implements _i2.StaleMateRefreshResult<T> {
-  _FakeStaleMateRefreshResult_0(
+class _FakeStaleMateLoaderState_0 extends _i1.SmartFake
+    implements _i2.StaleMateLoaderState {
+  _FakeStaleMateLoaderState_0(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -35,12 +38,242 @@ class _FakeStaleMateRefreshResult_0<T> extends _i1.SmartFake
         );
 }
 
-/// A class which mocks [StaleMateLoaderImpl1].
+class _FakeStaleMateRefreshResult_1<T> extends _i1.SmartFake
+    implements _i3.StaleMateRefreshResult<T> {
+  _FakeStaleMateRefreshResult_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+/// A class which mocks [StaleMateLoader1].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStaleMateLoaderImpl1 extends _i1.Mock
-    implements _i3.StaleMateLoaderImpl1 {
-  MockStaleMateLoaderImpl1() {
+class MockStaleMateLoader1 extends _i1.Mock implements _i4.StaleMateLoader1 {
+  MockStaleMateLoader1() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  bool get updateOnInit => (super.noSuchMethod(
+        Invocation.getter(#updateOnInit),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get showLocalDataOnError => (super.noSuchMethod(
+        Invocation.getter(#showLocalDataOnError),
+        returnValue: false,
+      ) as bool);
+  @override
+  _i5.Stream<String> get stream => (super.noSuchMethod(
+        Invocation.getter(#stream),
+        returnValue: _i5.Stream<String>.empty(),
+      ) as _i5.Stream<String>);
+  @override
+  String get value => (super.noSuchMethod(
+        Invocation.getter(#value),
+        returnValue: '',
+      ) as String);
+  @override
+  bool get isEmpty => (super.noSuchMethod(
+        Invocation.getter(#isEmpty),
+        returnValue: false,
+      ) as bool);
+  @override
+  _i2.StaleMateLoaderState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _FakeStaleMateLoaderState_0(
+          this,
+          Invocation.getter(#state),
+        ),
+      ) as _i2.StaleMateLoaderState);
+  @override
+  void addStateListener(_i6.StateListener? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addStateListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeStateListener(_i6.StateListener? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeStateListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  _i5.Future<void> addData(String? data) => (super.noSuchMethod(
+        Invocation.method(
+          #addData,
+          [data],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  _i5.Future<void> initialize() => (super.noSuchMethod(
+        Invocation.method(
+          #initialize,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  _i5.Future<_i3.StaleMateRefreshResult<String>> refresh() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [],
+        ),
+        returnValue: _i5.Future<_i3.StaleMateRefreshResult<String>>.value(
+            _FakeStaleMateRefreshResult_1<String>(
+          this,
+          Invocation.method(
+            #refresh,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i3.StaleMateRefreshResult<String>>);
+  @override
+  _i5.Future<void> reset() => (super.noSuchMethod(
+        Invocation.method(
+          #reset,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  void setLogLevel(_i2.StaleMateLogLevel? logLevel) => super.noSuchMethod(
+        Invocation.method(
+          #setLogLevel,
+          [logLevel],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [StaleMateLoader2].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockStaleMateLoader2 extends _i1.Mock implements _i4.StaleMateLoader2 {
+  MockStaleMateLoader2() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  bool get updateOnInit => (super.noSuchMethod(
+        Invocation.getter(#updateOnInit),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get showLocalDataOnError => (super.noSuchMethod(
+        Invocation.getter(#showLocalDataOnError),
+        returnValue: false,
+      ) as bool);
+  @override
+  _i5.Stream<int> get stream => (super.noSuchMethod(
+        Invocation.getter(#stream),
+        returnValue: _i5.Stream<int>.empty(),
+      ) as _i5.Stream<int>);
+  @override
+  int get value => (super.noSuchMethod(
+        Invocation.getter(#value),
+        returnValue: 0,
+      ) as int);
+  @override
+  bool get isEmpty => (super.noSuchMethod(
+        Invocation.getter(#isEmpty),
+        returnValue: false,
+      ) as bool);
+  @override
+  _i2.StaleMateLoaderState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _FakeStaleMateLoaderState_0(
+          this,
+          Invocation.getter(#state),
+        ),
+      ) as _i2.StaleMateLoaderState);
+  @override
+  void addStateListener(_i6.StateListener? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addStateListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void removeStateListener(_i6.StateListener? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeStateListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  _i5.Future<void> addData(int? data) => (super.noSuchMethod(
+        Invocation.method(
+          #addData,
+          [data],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  _i5.Future<void> initialize() => (super.noSuchMethod(
+        Invocation.method(
+          #initialize,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  _i5.Future<_i3.StaleMateRefreshResult<int>> refresh() => (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [],
+        ),
+        returnValue: _i5.Future<_i3.StaleMateRefreshResult<int>>.value(
+            _FakeStaleMateRefreshResult_1<int>(
+          this,
+          Invocation.method(
+            #refresh,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i3.StaleMateRefreshResult<int>>);
+  @override
+  _i5.Future<void> reset() => (super.noSuchMethod(
+        Invocation.method(
+          #reset,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+  @override
+  void setLogLevel(_i2.StaleMateLogLevel? logLevel) => super.noSuchMethod(
+        Invocation.method(
+          #setLogLevel,
+          [logLevel],
+        ),
+        returnValueForMissingStub: null,
+      );
+}
+
+/// A class which mocks [StaleMateHandlerImpl1].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockStaleMateHandlerImpl1 extends _i1.Mock
+    implements _i4.StaleMateHandlerImpl1 {
+  MockStaleMateHandlerImpl1() {
     _i1.throwOnMissingStub(this);
   }
 
@@ -50,110 +283,47 @@ class MockStaleMateLoaderImpl1 extends _i1.Mock
         returnValue: '',
       ) as String);
   @override
-  bool get updateOnInit => (super.noSuchMethod(
-        Invocation.getter(#updateOnInit),
-        returnValue: false,
-      ) as bool);
-  @override
-  bool get showLocalDataOnError => (super.noSuchMethod(
-        Invocation.getter(#showLocalDataOnError),
-        returnValue: false,
-      ) as bool);
-  @override
-  _i4.Stream<String> get stream => (super.noSuchMethod(
-        Invocation.getter(#stream),
-        returnValue: _i4.Stream<String>.empty(),
-      ) as _i4.Stream<String>);
-  @override
-  String get value => (super.noSuchMethod(
-        Invocation.getter(#value),
-        returnValue: '',
-      ) as String);
-  @override
-  _i4.Future<String> getLocalData() => (super.noSuchMethod(
+  _i5.Future<String> getLocalData() => (super.noSuchMethod(
         Invocation.method(
           #getLocalData,
           [],
         ),
-        returnValue: _i4.Future<String>.value(''),
-      ) as _i4.Future<String>);
+        returnValue: _i5.Future<String>.value(''),
+      ) as _i5.Future<String>);
   @override
-  _i4.Future<String> getRemoteData() => (super.noSuchMethod(
+  _i5.Future<String> getRemoteData() => (super.noSuchMethod(
         Invocation.method(
           #getRemoteData,
           [],
         ),
-        returnValue: _i4.Future<String>.value(''),
-      ) as _i4.Future<String>);
+        returnValue: _i5.Future<String>.value(''),
+      ) as _i5.Future<String>);
   @override
-  _i4.Future<void> storeLocalData(String? data) => (super.noSuchMethod(
+  _i5.Future<void> storeLocalData(String? data) => (super.noSuchMethod(
         Invocation.method(
           #storeLocalData,
           [data],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i4.Future<void> removeLocalData() => (super.noSuchMethod(
+  _i5.Future<void> removeLocalData() => (super.noSuchMethod(
         Invocation.method(
           #removeLocalData,
           [],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  _i4.Future<void> addData(String? data) => (super.noSuchMethod(
-        Invocation.method(
-          #addData,
-          [data],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  _i4.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(
-          #initialize,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  _i4.Future<_i2.StaleMateRefreshResult<String>> refresh() =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #refresh,
-          [],
-        ),
-        returnValue: _i4.Future<_i2.StaleMateRefreshResult<String>>.value(
-            _FakeStaleMateRefreshResult_0<String>(
-          this,
-          Invocation.method(
-            #refresh,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.StaleMateRefreshResult<String>>);
-  @override
-  _i4.Future<void> reset() => (super.noSuchMethod(
-        Invocation.method(
-          #reset,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
-/// A class which mocks [StaleMateLoaderImpl2].
+/// A class which mocks [StaleMateHandlerImpl2].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStaleMateLoaderImpl2 extends _i1.Mock
-    implements _i3.StaleMateLoaderImpl2 {
-  MockStaleMateLoaderImpl2() {
+class MockStaleMateHandlerImpl2 extends _i1.Mock
+    implements _i4.StaleMateHandlerImpl2 {
+  MockStaleMateHandlerImpl2() {
     _i1.throwOnMissingStub(this);
   }
 
@@ -163,99 +333,37 @@ class MockStaleMateLoaderImpl2 extends _i1.Mock
         returnValue: 0,
       ) as int);
   @override
-  bool get updateOnInit => (super.noSuchMethod(
-        Invocation.getter(#updateOnInit),
-        returnValue: false,
-      ) as bool);
-  @override
-  bool get showLocalDataOnError => (super.noSuchMethod(
-        Invocation.getter(#showLocalDataOnError),
-        returnValue: false,
-      ) as bool);
-  @override
-  _i4.Stream<int> get stream => (super.noSuchMethod(
-        Invocation.getter(#stream),
-        returnValue: _i4.Stream<int>.empty(),
-      ) as _i4.Stream<int>);
-  @override
-  int get value => (super.noSuchMethod(
-        Invocation.getter(#value),
-        returnValue: 0,
-      ) as int);
-  @override
-  _i4.Future<int> getLocalData() => (super.noSuchMethod(
+  _i5.Future<int> getLocalData() => (super.noSuchMethod(
         Invocation.method(
           #getLocalData,
           [],
         ),
-        returnValue: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
   @override
-  _i4.Future<int> getRemoteData() => (super.noSuchMethod(
+  _i5.Future<int> getRemoteData() => (super.noSuchMethod(
         Invocation.method(
           #getRemoteData,
           [],
         ),
-        returnValue: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
   @override
-  _i4.Future<void> storeLocalData(int? data) => (super.noSuchMethod(
+  _i5.Future<void> storeLocalData(int? data) => (super.noSuchMethod(
         Invocation.method(
           #storeLocalData,
           [data],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
   @override
-  _i4.Future<void> removeLocalData() => (super.noSuchMethod(
+  _i5.Future<void> removeLocalData() => (super.noSuchMethod(
         Invocation.method(
           #removeLocalData,
           [],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  _i4.Future<void> addData(int? data) => (super.noSuchMethod(
-        Invocation.method(
-          #addData,
-          [data],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  _i4.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(
-          #initialize,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
-  _i4.Future<_i2.StaleMateRefreshResult<int>> refresh() => (super.noSuchMethod(
-        Invocation.method(
-          #refresh,
-          [],
-        ),
-        returnValue: _i4.Future<_i2.StaleMateRefreshResult<int>>.value(
-            _FakeStaleMateRefreshResult_0<int>(
-          this,
-          Invocation.method(
-            #refresh,
-            [],
-          ),
-        )),
-      ) as _i4.Future<_i2.StaleMateRefreshResult<int>>);
-  @override
-  _i4.Future<void> reset() => (super.noSuchMethod(
-        Invocation.method(
-          #reset,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }


### PR DESCRIPTION
This PR is a significant refactor of the StaleMate library aimed at simplifying the codebase and improving its flexibility and maintainability. The main change involves shifting the responsibility of interfacing with local and remote data sources to a new set of classes called StaleMateHandlers, instead of the loaders themselves.

The benefits of this change include:
1. **Simplified Loaders**: The Loaders are now less complex and easier to maintain, as their sole responsibility is to manage data and state, not handle data retrieval or storage.
2. **Flexible Handler Options**: The PR introduces three variants of StaleMateHandlers:
    - **StaleMateHandler***: The base class requiring you to implement the **getLocalData**, **getRemoteData**, **storeLocalData**, and **removeLocalData** methods. This class is suitable when you have both local and remote data sources.
    - **LocalOnlyStaleMateHandler**: A simpler class where you only need to implement the local data methods, ideal for when your data resides only locally.
    - **RemoteOnlyStaleMateHandler**: This class requires you to implement only the getRemoteData method and is useful when you fetch data only from remote sources.
3. **Error Prevention**: With the StaleMateHandler classes, developers are now required to override the necessary methods, which helps prevent accidental misuses. Before this change, the developers would extend the loaders themselves and override the methods that they wanted to implement, leaving the other methods to their default implementations. Now they need to explicitly decide which kind of Handler they want to use and implement all the methods for that handler.
4. **Paginated Data Support**: A new **PaginatedHandlerMixin** has been added, which can be used with either the base StaleMateHandler or the RemoteOnlyStaleMateHandler to add support for pagination.